### PR TITLE
Add local Tailwind CSS loader plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,9 +74,12 @@
     "release:local": "pnpm build && changeset version && changeset publish && git add . && git commit -m \"chore: version packages\" && git push && git push --tags"
   },
   "dependencies": {
+    "@alloc/quick-lru": "5.2.0",
     "@react-router/node": "^7.13.0",
     "@remix-run/node-fetch-server": "^0.13.0",
     "@rspack/plugin-react-refresh": "^2.0.2",
+    "@tailwindcss/node": "4.3.2",
+    "@tailwindcss/oxide": "4.3.2",
     "execa": "^9.6.1",
     "fs-extra": "11.3.3",
     "isbot": "5.1.34",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@alloc/quick-lru':
+        specifier: 5.2.0
+        version: 5.2.0
       '@react-router/node':
         specifier: ^7.13.0
         version: 7.18.0(react-router@7.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
@@ -20,6 +23,12 @@ importers:
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.2
         version: 2.0.2(@rspack/core@2.1.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(react-refresh@0.18.0)
+      '@tailwindcss/node':
+        specifier: 4.3.2
+        version: 4.3.2
+      '@tailwindcss/oxide':
+        specifier: 4.3.2
+        version: 4.3.2
       execa:
         specifier: ^9.6.1
         version: 9.6.1

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -13,6 +13,7 @@ const config = defineConfig({
           index: './src/index.ts',
           'parallel-route-transform-worker':
             './src/parallel-route-transform-worker.ts',
+          'tailwind-loader': './src/tailwind-loader.ts',
           'templates/entry.server': './src/templates/entry.server.tsx',
           'templates/entry.client': './src/templates/entry.client.tsx',
         },
@@ -23,6 +24,7 @@ const config = defineConfig({
       source: {
         entry: {
           index: './src/index.ts',
+          'tailwind-loader': './src/tailwind-loader.ts',
           'templates/entry.server': './src/templates/entry.server.tsx',
           'templates/entry.client': './src/templates/entry.client.tsx',
         },
@@ -37,6 +39,9 @@ const config = defineConfig({
         /^react-router-dom/,
         /^react-router/,
         /^@react-router/,
+        /^@tailwindcss\/node(?:\/.*)?$/,
+        /^@tailwindcss\/oxide(?:\/.*)?$/,
+        '@alloc/quick-lru',
         'react',
         /^react-dom/,
       ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,10 @@ import {
 
 export { loadReactRouterServerBuild } from './dev-generation.js';
 export { resolveReactRouterServerBuild };
+export {
+  pluginReactRouterTailwindcss,
+  type ReactRouterTailwindcssPluginOptions,
+} from './tailwindcss-plugin.js';
 
 const MIN_PARALLEL_ENVIRONMENT_BUILD_SPARE_CORES = 4;
 

--- a/src/tailwind-loader.ts
+++ b/src/tailwind-loader.ts
@@ -1,0 +1,499 @@
+import QuickLRU from '@alloc/quick-lru';
+import {
+  compile,
+  env,
+  Instrumentation,
+  normalizePath,
+  optimize,
+} from '@tailwindcss/node';
+import { clearRequireCache } from '@tailwindcss/node/require-cache';
+import { Scanner, type ChangedContent } from '@tailwindcss/oxide';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DEBUG = env.DEBUG;
+const TAILWIND_FEATURES = {
+  None: 0,
+  AtApply: 1,
+  JsPluginCompat: 4,
+  ThemeFunction: 8,
+  Utilities: 16,
+} as const;
+const TAILWIND_POLYFILLS = {
+  All: 3,
+  AtProperty: 1,
+} as const;
+
+export interface TailwindLoaderOptions {
+  /**
+   * The base directory to scan for class candidates.
+   *
+   * Defaults to the current working directory.
+   */
+  base?: string;
+
+  /**
+   * Optimize and minify the output CSS.
+   */
+  optimize?: boolean | { minify?: boolean };
+}
+
+type LoaderCallback = (err?: Error | null, content?: string | Buffer) => void;
+
+type LoaderCompiler = {
+  modifiedFiles?: ReadonlySet<string>;
+  removedFiles?: ReadonlySet<string>;
+};
+
+type TailwindLoaderContext = {
+  resource: string;
+  resourcePath: string;
+  async(): LoaderCallback;
+  getOptions(): TailwindLoaderOptions | undefined;
+  addDependency(file: string): void;
+  addContextDependency(context: string): void;
+  _compiler?: LoaderCompiler;
+};
+
+type TailwindCompiler = Awaited<ReturnType<typeof compile>>;
+
+interface CacheEntry {
+  mtimes: Map<string, number>;
+  compiler: null | TailwindCompiler;
+  scanner: null | Scanner;
+  candidates: Set<string>;
+  fileCandidates: Map<string, Set<string>>;
+  fullRebuildPaths: string[];
+  result: string | null;
+}
+
+type CandidateUpdate = {
+  file: string;
+  nextCandidates: Set<string>;
+};
+
+type CandidateUpdateResult =
+  | { type: 'unknown' }
+  | { type: 'unchanged'; updates: CandidateUpdate[] }
+  | { type: 'additive'; updates: CandidateUpdate[] }
+  | { type: 'requires-full-scan' };
+
+const cache = new QuickLRU<string, CacheEntry>({ maxSize: 50 });
+
+const getCacheKey = (resourceId: string, opts: TailwindLoaderOptions): string =>
+  `${resourceId}:${opts.base ?? ''}:${JSON.stringify(opts.optimize)}`;
+
+const getContextFromCache = (
+  resourceId: string,
+  opts: TailwindLoaderOptions
+): CacheEntry => {
+  const key = getCacheKey(resourceId, opts);
+  if (cache.has(key)) {
+    return cache.get(key)!;
+  }
+
+  const entry: CacheEntry = {
+    mtimes: new Map<string, number>(),
+    compiler: null,
+    scanner: null,
+    candidates: new Set<string>(),
+    fileCandidates: new Map<string, Set<string>>(),
+    fullRebuildPaths: [],
+    result: null,
+  };
+  cache.set(key, entry);
+  return entry;
+};
+
+const setsEqual = (left: Set<string>, right: Set<string>): boolean => {
+  if (left.size !== right.size) {
+    return false;
+  }
+
+  for (const value of left) {
+    if (!right.has(value)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const scanFileCandidates = (scanner: Scanner, file: string): Set<string> => {
+  const input: ChangedContent = {
+    file,
+    content: fs.readFileSync(file, 'utf8'),
+    extension: path.extname(file).slice(1),
+  };
+
+  return new Set(scanner.scanFiles([input]));
+};
+
+const getModifiedFiles = (
+  loaderContext: TailwindLoaderContext,
+  inputFile: string,
+  fullRebuildPaths: string[]
+): string[] | null => {
+  const { modifiedFiles, removedFiles } = loaderContext._compiler ?? {};
+
+  if (removedFiles && removedFiles.size > 0) {
+    return null;
+  }
+
+  if (!modifiedFiles || modifiedFiles.size === 0) {
+    return null;
+  }
+
+  const fullRebuildPathSet = new Set(
+    [inputFile, ...fullRebuildPaths].map(file => path.resolve(file))
+  );
+  const changedFiles = [...modifiedFiles].map(file => path.resolve(file));
+
+  if (changedFiles.some(file => fullRebuildPathSet.has(file))) {
+    return null;
+  }
+
+  return changedFiles.filter(file => {
+    try {
+      return fs.statSync(file).isFile();
+    } catch {
+      return false;
+    }
+  });
+};
+
+const applyCandidateUpdates = (
+  context: CacheEntry,
+  updates: CandidateUpdate[]
+): void => {
+  for (const update of updates) {
+    for (const candidate of update.nextCandidates) {
+      context.candidates.add(candidate);
+    }
+    context.fileCandidates.set(update.file, update.nextCandidates);
+  }
+};
+
+const rememberFileCandidates = (
+  context: CacheEntry,
+  files: string[] | null
+): void => {
+  if (!context.scanner || !files) {
+    return;
+  }
+
+  for (const file of files) {
+    try {
+      context.fileCandidates.set(
+        path.resolve(file),
+        scanFileCandidates(context.scanner, file)
+      );
+    } catch {
+      context.fileCandidates.delete(path.resolve(file));
+    }
+  }
+};
+
+const registerDependencies = (
+  loaderContext: TailwindLoaderContext,
+  context: CacheEntry,
+  compiler: TailwindCompiler,
+  base: string,
+  inputFile: string
+): void => {
+  for (const file of context.fullRebuildPaths) {
+    loaderContext.addDependency(path.resolve(file));
+  }
+
+  if (!context.scanner) {
+    return;
+  }
+
+  const resolvedInputFile = path.resolve(base, inputFile);
+  for (const file of context.scanner.files) {
+    const absolutePath = path.resolve(file);
+    if (absolutePath !== resolvedInputFile) {
+      loaderContext.addDependency(absolutePath);
+    }
+  }
+
+  for (const glob of context.scanner.globs) {
+    if (glob.pattern[0] === '!') {
+      continue;
+    }
+    if (glob.pattern === '*' && base === glob.base) {
+      continue;
+    }
+
+    loaderContext.addContextDependency(path.resolve(glob.base));
+  }
+
+  const root = compiler.root;
+  if (root === 'none' || root === null) {
+    return;
+  }
+
+  const basePath = normalizePath(path.resolve(root.base, root.pattern));
+  try {
+    const stats = fs.statSync(basePath);
+    if (!stats.isDirectory()) {
+      throw new Error(
+        `The path given to \`source(…)\` must be a directory but got \`source(${basePath})\` instead.`
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+};
+
+const getCandidateUpdate = (
+  context: CacheEntry,
+  modifiedFiles: string[] | null
+): CandidateUpdateResult => {
+  if (!context.scanner) {
+    return { type: 'unknown' };
+  }
+
+  if (!modifiedFiles || modifiedFiles.length === 0) {
+    return { type: 'unknown' };
+  }
+
+  let hasChangedCandidates = false;
+  let hasRemovedCandidates = false;
+  const updates: CandidateUpdate[] = [];
+
+  for (const file of modifiedFiles) {
+    const resolvedFile = path.resolve(file);
+    const previousCandidates = context.fileCandidates.get(resolvedFile);
+    if (!previousCandidates) {
+      return { type: 'unknown' };
+    }
+
+    const nextCandidates = scanFileCandidates(context.scanner, file);
+    updates.push({
+      file: resolvedFile,
+      nextCandidates,
+    });
+
+    if (setsEqual(previousCandidates, nextCandidates)) {
+      continue;
+    }
+
+    hasChangedCandidates = true;
+    for (const candidate of previousCandidates) {
+      if (!nextCandidates.has(candidate)) {
+        hasRemovedCandidates = true;
+        break;
+      }
+    }
+  }
+
+  if (!hasChangedCandidates) {
+    return { type: 'unchanged', updates };
+  }
+
+  if (hasRemovedCandidates) {
+    return { type: 'requires-full-scan' };
+  }
+
+  return { type: 'additive', updates };
+};
+
+export default async function tailwindLoader(
+  this: TailwindLoaderContext,
+  source: string
+): Promise<void> {
+  const callback = this.async();
+  const options = this.getOptions() ?? {};
+  const inputFile = this.resourcePath;
+  const resourceId = this.resource;
+  const base = options.base ?? process.cwd();
+  const shouldOptimize =
+    options.optimize ?? process.env.NODE_ENV === 'production';
+  const isCSSModuleFile = inputFile.endsWith('.module.css');
+  const instrumentation = new Instrumentation();
+
+  DEBUG &&
+    instrumentation.start(
+      `[@tailwindcss/webpack] ${path.relative(base, inputFile)}`
+    );
+
+  if (
+    !/@(import|reference|theme|variant|config|plugin|apply|tailwind)\b/.test(
+      source
+    )
+  ) {
+    DEBUG &&
+      instrumentation.end(
+        `[@tailwindcss/webpack] ${path.relative(base, inputFile)}`
+      );
+    callback(null, source);
+    return;
+  }
+
+  try {
+    const context = getContextFromCache(resourceId, options);
+    const inputBasePath = path.dirname(path.resolve(inputFile));
+    const isInitialBuild = context.compiler === null;
+
+    const createCompiler = async (): Promise<TailwindCompiler> => {
+      if (context.fullRebuildPaths.length > 0 && !isInitialBuild) {
+        clearRequireCache(context.fullRebuildPaths);
+      }
+
+      context.fullRebuildPaths = [];
+
+      const polyfills = (
+        isCSSModuleFile
+          ? TAILWIND_POLYFILLS.All ^ TAILWIND_POLYFILLS.AtProperty
+          : TAILWIND_POLYFILLS.All
+      ) as Parameters<typeof compile>[1]['polyfills'];
+
+      return compile(source, {
+        from: inputFile,
+        base: inputBasePath,
+        shouldRewriteUrls: true,
+        onDependency: depPath => context.fullRebuildPaths.push(depPath),
+        polyfills,
+      });
+    };
+
+    context.compiler ??= await createCompiler();
+
+    if (context.compiler.features === TAILWIND_FEATURES.None) {
+      DEBUG &&
+        instrumentation.end(
+          `[@tailwindcss/webpack] ${path.relative(base, inputFile)}`
+        );
+      callback(null, source);
+      return;
+    }
+
+    let rebuildStrategy: 'full' | 'incremental' = 'incremental';
+
+    for (const file of [...context.fullRebuildPaths, inputFile]) {
+      let changedTime: number | null = null;
+      try {
+        changedTime = fs.statSync(file)?.mtimeMs ?? null;
+      } catch {
+        // File might not exist.
+      }
+
+      if (changedTime === null) {
+        if (file === inputFile) {
+          rebuildStrategy = 'full';
+        }
+        continue;
+      }
+
+      const prevTime = context.mtimes.get(file);
+      if (prevTime === changedTime) {
+        continue;
+      }
+
+      rebuildStrategy = 'full';
+      context.mtimes.set(file, changedTime);
+    }
+
+    if (rebuildStrategy === 'full' && !isInitialBuild) {
+      context.compiler = await createCompiler();
+    }
+
+    const compiler = context.compiler;
+
+    if (
+      !(
+        compiler.features &
+        (TAILWIND_FEATURES.AtApply |
+          TAILWIND_FEATURES.JsPluginCompat |
+          TAILWIND_FEATURES.ThemeFunction |
+          TAILWIND_FEATURES.Utilities)
+      )
+    ) {
+      DEBUG &&
+        instrumentation.end(
+          `[@tailwindcss/webpack] ${path.relative(base, inputFile)}`
+        );
+      callback(null, source);
+      return;
+    }
+
+    if (context.scanner === null || rebuildStrategy === 'full') {
+      const sources = (() => {
+        if (compiler.root === 'none') {
+          return [];
+        }
+        if (compiler.root === null) {
+          return [{ base, pattern: '**/*', negated: false }];
+        }
+        return [{ ...compiler.root, negated: false }];
+      })().concat(compiler.sources);
+
+      context.scanner = new Scanner({ sources });
+      context.fileCandidates.clear();
+    }
+
+    if (compiler.features & TAILWIND_FEATURES.Utilities) {
+      const modifiedFiles = getModifiedFiles(
+        this,
+        inputFile,
+        context.fullRebuildPaths
+      );
+      const candidateUpdate =
+        !isInitialBuild && rebuildStrategy === 'incremental'
+          ? getCandidateUpdate(context, modifiedFiles)
+          : { type: 'unknown' as const };
+
+      if (candidateUpdate.type === 'unchanged' && context.result !== null) {
+        applyCandidateUpdates(context, candidateUpdate.updates);
+        registerDependencies(this, context, compiler, base, inputFile);
+        DEBUG &&
+          instrumentation.end(
+            `[@tailwindcss/webpack] ${path.relative(base, inputFile)}`
+          );
+        callback(null, context.result!);
+        return;
+      }
+
+      if (candidateUpdate.type === 'additive') {
+        applyCandidateUpdates(context, candidateUpdate.updates);
+      } else {
+        context.candidates.clear();
+        for (const candidate of context.scanner.scan()) {
+          context.candidates.add(candidate);
+        }
+
+        rememberFileCandidates(context, modifiedFiles);
+      }
+
+      registerDependencies(this, context, compiler, base, inputFile);
+    }
+
+    let result = compiler.build([...context.candidates]);
+    if (shouldOptimize) {
+      result = optimize(result, {
+        minify:
+          typeof shouldOptimize === 'object' ? shouldOptimize.minify : true,
+      }).code;
+    }
+
+    context.result = result;
+
+    DEBUG &&
+      instrumentation.end(
+        `[@tailwindcss/webpack] ${path.relative(base, inputFile)}`
+      );
+    callback(null, result);
+  } catch (error) {
+    const key = getCacheKey(resourceId, options);
+    cache.delete(key);
+
+    DEBUG &&
+      instrumentation.end(
+        `[@tailwindcss/webpack] ${path.relative(base, inputFile)}`
+      );
+    callback(error as Error);
+  }
+}

--- a/src/tailwindcss-plugin.ts
+++ b/src/tailwindcss-plugin.ts
@@ -1,0 +1,120 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Minify, RsbuildPlugin, RspackChain } from '@rsbuild/core';
+
+export const PLUGIN_REACT_ROUTER_TAILWINDCSS_NAME = 'react-router:tailwindcss';
+
+export type ReactRouterTailwindcssPluginOptions = {
+  /**
+   * The base directory for Tailwind CSS to scan source files.
+   *
+   * @default api.context.rootPath
+   */
+  base?: string;
+
+  /**
+   * Enable Tailwind CSS's built-in Lightning CSS optimization.
+   *
+   * By default, this is enabled in production mode and disabled in development
+   * mode. Minification follows Rsbuild's CSS minification config.
+   */
+  optimize?:
+    | boolean
+    | {
+        minify?: boolean;
+      };
+};
+
+const getTailwindLoaderPath = (): string =>
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    import.meta.url.endsWith('.cjs')
+      ? 'tailwind-loader.cjs'
+      : 'tailwind-loader.js'
+  );
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const incrementCssImportLoaders = (
+  rule: RspackChain.Rule<unknown>,
+  cssUseId: string
+): void => {
+  if (!rule.uses.has(cssUseId)) {
+    return;
+  }
+
+  const cssLoader = rule.uses.get(cssUseId);
+  const options = cssLoader.get('options');
+
+  if (!isRecord(options)) {
+    return;
+  }
+
+  cssLoader.options({
+    ...options,
+    importLoaders:
+      typeof options.importLoaders === 'number' ? options.importLoaders + 1 : 1,
+  });
+};
+
+const isCssMinifyEnabled = (
+  minify: Minify | undefined,
+  isProd: boolean
+): boolean => {
+  if (typeof minify === 'boolean' || minify === undefined) {
+    return (minify ?? true) && isProd;
+  }
+
+  return minify.css !== false && (minify.css === 'always' || isProd);
+};
+
+export const pluginReactRouterTailwindcss = (
+  options: ReactRouterTailwindcssPluginOptions = {}
+): RsbuildPlugin => ({
+  name: PLUGIN_REACT_ROUTER_TAILWINDCSS_NAME,
+
+  setup(api) {
+    api.modifyBundlerChain(
+      (chain, { CHAIN_ID, environment, isProd, target }) => {
+        if (!chain.module.rules.has(CHAIN_ID.RULE.CSS)) {
+          return;
+        }
+
+        const { output } = environment.config;
+
+        let { optimize } = options;
+        if (optimize === undefined) {
+          if (isProd) {
+            optimize = { minify: isCssMinifyEnabled(output.minify, isProd) };
+          } else {
+            optimize = false;
+          }
+        }
+
+        const tailwindOptions = {
+          base: options.base ?? api.context.rootPath,
+          optimize,
+        };
+        const emitCss = output.emitCss ?? target === 'web';
+        const tailwindLoaderPath = getTailwindLoaderPath();
+
+        const addTailwindLoader = (rule: RspackChain.Rule<unknown>): void => {
+          incrementCssImportLoaders(rule, CHAIN_ID.USE.CSS);
+
+          rule
+            .use('tailwindcss')
+            .loader(tailwindLoaderPath)
+            .options(tailwindOptions);
+        };
+
+        const cssRule = chain.module.rule(CHAIN_ID.RULE.CSS);
+        addTailwindLoader(cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_URL));
+        if (emitCss) {
+          addTailwindLoader(cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_MAIN));
+        }
+        addTailwindLoader(cssRule.oneOf(CHAIN_ID.ONE_OF.CSS_INLINE));
+      }
+    );
+  },
+});

--- a/tests/tailwindcss-plugin.test.ts
+++ b/tests/tailwindcss-plugin.test.ts
@@ -1,0 +1,59 @@
+import { createRsbuild, type Rspack } from '@rsbuild/core';
+import { describe, expect, it } from '@rstest/core';
+import { pluginReactRouterTailwindcss } from '../src';
+
+type Rule = NonNullable<Rspack.Configuration['module']>['rules'][number];
+type RuleUse = {
+  loader?: string;
+  options?: Record<string, unknown>;
+};
+
+const getTailwindLoaders = (rule: Rule): RuleUse[] => {
+  if (!rule || typeof rule !== 'object' || !('oneOf' in rule)) {
+    return [];
+  }
+
+  return (rule.oneOf ?? []).flatMap(oneOf => {
+    if (!oneOf || typeof oneOf !== 'object' || !('use' in oneOf)) {
+      return [];
+    }
+
+    const uses = Array.isArray(oneOf.use) ? oneOf.use : [oneOf.use];
+    return uses.filter(
+      (use): use is RuleUse =>
+        Boolean(
+          use &&
+            typeof use === 'object' &&
+            'loader' in use &&
+            typeof use.loader === 'string' &&
+            use.loader.includes('tailwind-loader')
+        )
+    );
+  });
+};
+
+describe('pluginReactRouterTailwindcss', () => {
+  it('adds the local Tailwind loader to CSS rules', async () => {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          pluginReactRouterTailwindcss({
+            base: '/custom/tailwind-base',
+          }),
+        ],
+      },
+    });
+
+    const [config] = await rsbuild.initConfigs();
+    const tailwindLoaders = (config.module?.rules ?? []).flatMap(rule =>
+      getTailwindLoaders(rule)
+    );
+
+    expect(tailwindLoaders).toHaveLength(3);
+    expect(tailwindLoaders.map(loader => loader.options?.base)).toEqual([
+      '/custom/tailwind-base',
+      '/custom/tailwind-base',
+      '/custom/tailwind-base',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `pluginReactRouterTailwindcss()` as a local Rsbuild-style Tailwind CSS plugin
- add a repo-local `tailwind-loader` forked from `@tailwindcss/webpack`
- on warm rebuilds, use `scanner.scanFiles(...)` for changed files with cached candidate comparison; return cached CSS when candidates are unchanged
- avoid pre-scanning every Tailwind source file for per-file candidate caches; cache changed files lazily and use full-scan fallback when needed
- emit ESM/CJS loader entries and externalize Tailwind runtime deps so `clearRequireCache` remains a direct external import/require

## Notes
- This makes an already-awakened CSS loader cheaper. It does not fully solve dependency narrowing: if Rspack invalidates the CSS module from registered file/context deps, the loader still wakes up.
- Broader Rspack HMR/chunk/hash work remains separate from this Tailwind loader path.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `tracedecay_diagnostics`: 0 errors, 0 warnings
- `pnpm rstest run -c ./rstest.config.ts tests/tailwindcss-plugin.test.ts`
- `pnpm prettier --check src/tailwind-loader.ts src/tailwindcss-plugin.ts src/index.ts rslib.config.ts tests/tailwindcss-plugin.test.ts package.json`
- `pnpm build`
- emitted `dist/tailwind-loader.{js,cjs}` checked for `clearRequireCache`, `@tailwindcss/node/require-cache`, `scanFiles`, and `.scan()`
- built ESM/CJS smoke checks verified three local loader entries with `/custom/tailwind-base`
