### PR TITLE
test: cover lazy compilation hydration workaround

### DIFF
--- a/examples/default-template/tests/e2e/lazy-compilation.test.ts
+++ b/examples/default-template/tests/e2e/lazy-compilation.test.ts
@@ -108,6 +108,27 @@ test.describe('lazy compilation', () => {
       errors.push(error.message);
     });
 
+    const documentRequests: string[] = [];
+    const websocketFrames: string[] = [];
+    page.on('request', (request) => {
+      if (
+        request.isNavigationRequest() &&
+        request.frame() === page.mainFrame()
+      ) {
+        documentRequests.push(request.url());
+      }
+    });
+    page.on('websocket', (websocket) => {
+      websocket.on('framereceived', ({ payload }) => {
+        websocketFrames.push(payload.toString());
+      });
+    });
+
+    // Workaround regression: React Router hydration modules stay eager while
+    // the application still opts into lazy entry compilation.
+    // TODO: After web-infra-dev/rspack#14753 and web-infra-dev/rsbuild#8091
+    // ship, expect reload-free lazy activation instead of an eager route asset.
+
     await page.goto('/');
 
     await page.waitForFunction(() => {
@@ -140,23 +161,17 @@ test.describe('lazy compilation', () => {
       'lazy-compilation-proxy'
     );
 
-    const documentRequests: string[] = [];
-    page.on('request', (request) => {
-      if (
-        request.isNavigationRequest() &&
-        request.frame() === page.mainFrame()
-      ) {
-        documentRequests.push(request.url());
-      }
-    });
-
     await page.locator('a[href="/about"]').first().click();
 
     await expect(page).toHaveURL('/about');
     await expect(
       page.locator('h1:has-text("About This Demo")')
     ).toBeVisible();
-    expect(documentRequests).toEqual([]);
+    await page.waitForTimeout(1000);
+    expect(documentRequests).toHaveLength(1);
+    expect(
+      websocketFrames.some((frame) => /"type"\s*:\s*"full-reload"/.test(frame))
+    ).toBe(false);
     expect(errors.join('\n')).not.toMatch(/hydration|Hydration|Component/);
   });
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "bench:full": "node scripts/bench-builds.mts --profile full --iterations 5 --warmup 1 --clean build --format both --out .benchmark/results/full",
     "bench:large": "node scripts/bench-builds.mts --profile large --iterations 1 --warmup 0 --clean cold --format both --out .benchmark/results/large",
     "bench:synthetic-app": "node scripts/bench-synthetic-app.mjs",
-    "e2e": "pnpm build && pnpm test:package-interop && pnpm --filter './examples/{default-template,spa-mode,prerender,custom-node-server,cloudflare,client-only}' test:e2e",
+    "e2e": "pnpm build && pnpm test:package-interop && pnpm --filter './examples/{default-template,spa-mode,prerender,custom-node-server,cloudflare,client-only}' test:e2e && pnpm --filter default-template test:e2e:lazy",
     "dev": "rslib build --watch",
     "test": "rstest run",
     "test:watch": "rstest watch",

--- a/src/index.ts
+++ b/src/index.ts
@@ -761,12 +761,16 @@ export const pluginReactRouter = (
         serverBundleEntries,
       });
 
+      // Prefer an explicit plugin option; otherwise preserve the user's
+      // Rsbuild dev.lazyCompilation value, including entries/imports/test.
       const configuredLazyCompilation = Object.prototype.hasOwnProperty.call(
         options,
         'lazyCompilation'
       )
         ? pluginOptions.lazyCompilation
         : (config.dev?.lazyCompilation ?? pluginOptions.lazyCompilation);
+      // TODO: Remove this hydration workaround after web-infra-dev/rspack#14753
+      // and web-infra-dev/rsbuild#8091 are available in our minimum versions.
       const guardedLazyCompilation = guardReactRouterLazyCompilation({
         lazyCompilation: configuredLazyCompilation,
         entryClientPath: finalEntryClientPath,

--- a/src/lazy-compilation.ts
+++ b/src/lazy-compilation.ts
@@ -48,6 +48,10 @@ const matchesLazyCompilationTest = (
 };
 
 const createReactRouterHydrationModuleTest = (entryClientPath: string) => {
+  // TODO: Remove these eager-module exceptions after web-infra-dev/rspack#14753
+  // and web-infra-dev/rsbuild#8091 are available in our minimum versions.
+  // Lazy activation currently changes the initial chunk set and makes Rsbuild
+  // reload the document before React Router can hydrate it.
   const eagerPatterns = [
     'virtual/react-router/browser-manifest',
     ...(entryClientPath
@@ -83,7 +87,11 @@ export const guardReactRouterLazyCompilation = ({
     lazyCompilation === true
       ? { entries: true, imports: true }
       : lazyCompilation;
+  // Preserve the user's entries/imports/test policy. The workaround only
+  // composes an eager exception for React Router's hydration-critical modules.
   const userTest = options.test;
+  // The unstable prewarm path deliberately activates React Router's client and
+  // route modules, so only the browser manifest remains eagerly compiled.
   const isReactRouterHydrationModule = prewarmReactRouterModules
     ? createReactRouterHydrationModuleTest('')
     : createReactRouterHydrationModuleTest(entryClientPath);


### PR DESCRIPTION
## Summary

- Document the current eager hydration-module workaround while preserving the user configured `entries`, `imports`, and `test` lazy-compilation policy.
- Strengthen the `entries: true` E2E assertion to reject document navigation and Rsbuild `full-reload` frames.
- Run the lazy entries-mode E2E suite from the root `e2e` command.

## Why

This is the conservative fallback: hydration-critical React Router modules stay eager. The opt-in scalable workaround that keeps non-hydration route entries lazy is in #97.

## Tests

- `pnpm build`
- `pnpm exec rstest run tests/index.test.ts`
- `pnpm --filter default-template test:e2e:lazy`

## Related

- Full-lazy route workaround: #97
- RR8 compatibility: #74
- Rspack provenance fix: web-infra-dev/rspack#14753
- Rsbuild reload handling: web-infra-dev/rsbuild#8091
