### PR TITLE
fix: stabilize route client entry requests

### DIFF
--- a/.changeset/stable-route-entry-paths.md
+++ b/.changeset/stable-route-entry-paths.md
@@ -1,0 +1,6 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Generate route client entry imports with relative requests so build output and
+content hashes stay stable when the same project is built from different paths.

--- a/src/route-artifacts.ts
+++ b/src/route-artifacts.ts
@@ -1,3 +1,4 @@
+import { basename } from 'pathe';
 import {
   CLIENT_EXPORTS,
   CLIENT_ROUTE_EXPORTS_SET,
@@ -175,11 +176,12 @@ export const buildRouteClientEntryCode = ({
     chunkedExports.length > 0 || sharedChunkedExports.length > 0
       ? new Set<string>([...chunkedExports, ...sharedChunkedExports])
       : undefined;
+  const routeRequestPath = `./${basename(resourcePath)}`;
   const target = isServer
-    ? resourcePath
+    ? routeRequestPath
     : chunkedExports.length > 0
-      ? getRouteChunkModuleId(resourcePath, 'main')
-      : `${resourcePath}?react-router-route`;
+      ? getRouteChunkModuleId(routeRequestPath, 'main')
+      : `${routeRequestPath}?react-router-route`;
   const reexports = exportNames
     .filter(exportName =>
       shouldReexportFromRouteEntry({ chunkedExportSet, exportName, isServer })
@@ -192,7 +194,7 @@ export const buildRouteClientEntryCode = ({
     ...sharedChunkedExports.map(
       exportName =>
         `export { ${exportName} } from ${JSON.stringify(
-          getRouteChunkModuleId(resourcePath, exportName)
+          getRouteChunkModuleId(routeRequestPath, exportName)
         )};`
     ),
   ]

--- a/tests/route-artifacts.test.ts
+++ b/tests/route-artifacts.test.ts
@@ -29,10 +29,11 @@ const enforceRouteChunkConfig: RouteChunkConfig = {
 };
 
 const resourcePath = '/app/routes/demo.tsx';
-const routeRequest = `${resourcePath}?react-router-route`;
-const mainRouteChunkRequest = getRouteChunkModuleId(resourcePath, 'main');
+const relativeResourcePath = './demo.tsx';
+const routeRequest = './demo.tsx?react-router-route';
+const mainRouteChunkRequest = getRouteChunkModuleId(relativeResourcePath, 'main');
 const customExportChunkRequest = getRouteChunkModuleId(
-  resourcePath,
+  relativeResourcePath,
   'customExport'
 );
 
@@ -56,6 +57,48 @@ const createRouteChunk = async (
 
 describe('route artifact helpers', () => {
   describe('createRouteClientEntryArtifact', () => {
+    it.each([
+      {
+        name: 'web route',
+        code: `export default function Route() { return null; }`,
+        environmentName: 'web',
+        config: disabledRouteChunkConfig,
+        expected: 'export { default } from "./demo.tsx?react-router-route";',
+      },
+      {
+        name: 'split route',
+        code: `
+          export async function clientLoader() { return null; }
+          export default function Route() { return null; }
+        `,
+        environmentName: 'web',
+        config: routeChunkConfig,
+        expected: 'export { default } from "./demo.tsx?route-chunk=main";',
+      },
+      {
+        name: 'server route',
+        code: `export default function Route() { return null; }`,
+        environmentName: 'node',
+        config: routeChunkConfig,
+        expected: 'export { default } from "./demo.tsx";',
+      },
+    ])('generates location-independent $name requests', async options => {
+      const createArtifact = (projectRoot: string) =>
+        createRouteClientEntryArtifact({
+          code: options.code,
+          resourcePath: `${projectRoot}/app/routes/demo.tsx`,
+          environmentName: options.environmentName,
+          isBuild: true,
+          routeChunkConfig: options.config,
+        });
+
+      const first = await createArtifact('/workspace-a');
+      const second = await createArtifact('/workspace-b');
+
+      expect(first).toEqual({ code: options.expected });
+      expect(second).toEqual(first);
+    });
+
     it('generates web route reexports that filter server-only exports', async () => {
       const result = await createRouteClientEntryArtifact({
         code: `
@@ -93,7 +136,7 @@ describe('route artifact helpers', () => {
 
       expect(result).toEqual({
         code: `export { action, clientLoader, default, loader } from ${JSON.stringify(
-          resourcePath
+          relativeResourcePath
         )};`,
       });
     });
@@ -178,7 +221,7 @@ describe('route artifact helpers', () => {
 
       expect(result).toEqual({
         code: `export { HydrateFallback, clientLoader, default } from ${JSON.stringify(
-          `${rootResourcePath}?react-router-route`
+          './root.tsx?react-router-route'
         )};`,
       });
     });


### PR DESCRIPTION
## Summary

- emit relative route client-entry requests instead of absolute filesystem paths
- cover web, split-route, shared-export, and server entry generation
- add a patch changeset

## Verification

- `pnpm test` (644 tests)
- `pnpm build`
- `pnpm --filter default-template build`
- verified default-template output contains no checkout path

Fixes #106