### PR TITLE
fix: relative route entry names, stable dev manifest version, CI stabilization

### DIFF
--- a/.changeset/route-entry-names-relative.md
+++ b/.changeset/route-entry-names-relative.md
@@ -1,0 +1,19 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Derive route entry names from the route file instead of the route id. A route
+table built with `relative()` resolves route files to absolute paths, so React
+Router relativizes `file` but leaves `id` absolute, and the plugin used that
+opaque id as an rspack entry name. Split route module chunks were therefore
+emitted into a directory tree mirroring the developer's checkout
+(`static/js/Users/<user>/.../customers-client-loader.js`) and the browser
+manifest published those paths, leaking `$HOME` into production assets and
+making builds unreproducible across machines and CI. Entry names are now
+app-relative for both the route entry and its chunks, so a chunk lands beside
+its route, the `"/static/js//..."` double slash is gone, and an entry can no
+longer escape the JS output directory or carry a Windows drive prefix. Route
+ids are untouched: they remain the runtime contract behind
+`useRouteLoaderData(id)` and `matches[].id`. Note that route chunks for routes
+declared with an explicit `id` are renamed accordingly, which changes those
+asset URLs.

--- a/.changeset/stable-dev-manifest-version.md
+++ b/.changeset/stable-dev-manifest-version.md
@@ -1,0 +1,14 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Derive the development browser manifest `version` from the manifest content
+instead of a random value per web compilation. The browser manifest asset is
+served from the latest web compilation while the server build stays pinned to
+the compilation it was committed with, so a web compilation that left the
+manifest unchanged (for example the hot data revalidation recompile after a
+server change) gave the two different versions. React Router's stale-client
+check then answered route discovery with a document reload, which could land
+mid-navigation and surface as a hydration mismatch. Equal manifests now share a
+version, and a real change still busts the browser cache through the `?v=`
+query on the development manifest URL.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,37 @@ jobs:
       - name: Build Project
         run: pnpm build
 
-      - name: Create Release Pull Request or Publish to npm
+      # The rstackjs organization does not allow GitHub Actions to open pull
+      # requests, so the changesets "Version Packages" PR cannot be created from
+      # this workflow. Apply pending changesets directly on the release branch
+      # instead: bump the version, write the changelog, commit, and push. The
+      # publish step below then runs against a tree with no pending changesets.
+      - name: Apply pending changesets
+        id: version
+        run: |
+          pending="$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l)"
+          if [ "$pending" = "0" ]; then
+            echo "No pending changesets; publishing current version."
+            echo "versioned=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pnpm changeset version
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          version="$(node -p "require('./package.json').version")"
+          git commit -m "chore: version packages (${version})"
+          git push origin "HEAD:${{ github.event.inputs.branch || github.ref_name }}"
+          echo "versioned=true" >> "$GITHUB_OUTPUT"
+          echo "Versioned to ${version}"
+
+      - name: Publish to npm
         id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
         with:
           # Run our custom release script that builds and publishes
           publish: pnpm release
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/classic-mode.ts
+++ b/src/classic-mode.ts
@@ -25,6 +25,7 @@ import {
 import {
   getRouteChunkEntryName,
   getRouteChunkModuleId,
+  getRouteEntryBaseName,
   routeChunkExportNames,
 } from './route-chunks.js';
 import type { Config } from './react-router-config.js';
@@ -144,7 +145,7 @@ export const createClassicWebRouteEntries = ({
   const manifestChunkNames = new Set<string>(['entry.client']);
   const webRouteEntries = Object.values(routes).reduce(
     (acc, route) => {
-      const entryName = route.file.slice(0, route.file.lastIndexOf('.'));
+      const entryName = getRouteEntryBaseName(route, appDirectory);
       const routeFilePath = resolve(appDirectory, route.file);
       manifestChunkNames.add(entryName);
       acc[entryName] = {
@@ -166,7 +167,11 @@ export const createClassicWebRouteEntries = ({
           if (!source.includes(exportName)) {
             continue;
           }
-          const chunkEntryName = getRouteChunkEntryName(route.id, exportName);
+          const chunkEntryName = getRouteChunkEntryName(
+            route,
+            exportName,
+            appDirectory
+          );
           manifestChunkNames.add(chunkEntryName);
           acc[chunkEntryName] = {
             import: getRouteChunkModuleId(routeFilePath, exportName),

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -413,18 +413,25 @@ export const getReactRouterManifestPath = ({
   return `${dir}/manifest-${version}.js`;
 };
 
-const getManifestVersion = (
-  fingerprintedValues: { entry: unknown; routes: unknown },
-  isBuild: boolean
-): string => {
-  if (!isBuild) {
-    return String(Math.random());
-  }
-  return createHash('md5')
+// The version is derived from the manifest content in every mode. React
+// Router's stale-client detection compares the version the browser loaded with
+// the one the server build was pinned to, and answers a mismatch with a
+// document reload. In development the browser manifest asset is served from
+// the latest web compilation while the server build stays pinned to the
+// compilation it was committed with, so a random per-compilation version made
+// the two disagree whenever a web compilation completed without changing the
+// manifest (for example the hot data revalidation recompile that follows a
+// server change), reloading the document for no reason. Equal content now
+// yields an equal version, and a real manifest change still busts the browser
+// cache through the `?v=` query on the development manifest URL.
+const getManifestVersion = (fingerprintedValues: {
+  entry: unknown;
+  routes: unknown;
+}): string =>
+  createHash('md5')
     .update(JSON.stringify(fingerprintedValues))
     .digest('hex')
     .slice(0, 8);
-};
 
 export const getReactRouterManifestChunkNames = (
   routes: Record<string, Route>,
@@ -618,7 +625,7 @@ function generateReactRouterManifestForDevEffect(
       },
       routes: result,
     };
-    const version = getManifestVersion(fingerprintedValues, isBuild);
+    const version = getManifestVersion(fingerprintedValues);
     const manifestPath = getReactRouterManifestPath({
       version,
       isBuild,

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -13,6 +13,7 @@ import {
   createEmptyRouteChunkByExportName,
   detectRouteChunksIfEnabled,
   getRouteChunkEntryName,
+  getRouteEntryBaseName,
   routeChunkExportNames,
   validateRouteChunks,
   type RouteChunkCache,
@@ -425,23 +426,19 @@ const getManifestVersion = (
     .slice(0, 8);
 };
 
-const getRouteEntryName = (route: Route): string => {
-  const extensionIndex = route.file.lastIndexOf('.');
-  return extensionIndex >= 0 ? route.file.slice(0, extensionIndex) : route.file;
-};
-
 export const getReactRouterManifestChunkNames = (
   routes: Record<string, Route>,
+  appDirectory: string,
   splitRouteModules: boolean | 'enforce' = false
 ): Set<string> => {
   const chunkNames = new Set<string>(['entry.client']);
   for (const route of Object.values(routes)) {
-    chunkNames.add(getRouteEntryName(route));
+    chunkNames.add(getRouteEntryBaseName(route, appDirectory));
     if (!splitRouteModules || route.id === 'root') {
       continue;
     }
     for (const exportName of routeChunkExportNames) {
-      chunkNames.add(getRouteChunkEntryName(route.id, exportName));
+      chunkNames.add(getRouteChunkEntryName(route, exportName, appDirectory));
     }
   }
   return chunkNames;
@@ -449,6 +446,7 @@ export const getReactRouterManifestChunkNames = (
 
 const createRouteManifestItem = ({
   route,
+  appDirectory,
   assetPrefix,
   jsAssets,
   routeAnalysis,
@@ -456,6 +454,7 @@ const createRouteManifestItem = ({
   getCssAssetsForChunk,
 }: {
   route: Route;
+  appDirectory: string;
   assetPrefix: string;
   jsAssets: string[];
   routeAnalysis: RouteManifestAnalysis;
@@ -465,13 +464,17 @@ const createRouteManifestItem = ({
   const routeChunkMap = routeAnalysis.hasRouteChunkByExportName;
   const chunkModulePath = (exportName: RouteChunkExportName) =>
     routeChunkMap?.[exportName]
-      ? getModulePathForChunk(getRouteChunkEntryName(route.id, exportName))
+      ? getModulePathForChunk(
+          getRouteChunkEntryName(route, exportName, appDirectory)
+        )
       : undefined;
   const cssAssets = [
     ...routeAnalysis.cssAssets,
     ...routeChunkExportNames.flatMap(exportName =>
       routeChunkMap?.[exportName]
-        ? getCssAssetsForChunk(getRouteChunkEntryName(route.id, exportName))
+        ? getCssAssetsForChunk(
+            getRouteChunkEntryName(route, exportName, appDirectory)
+          )
         : []
     ),
   ];
@@ -540,7 +543,7 @@ function generateReactRouterManifestForDevEffect(
       Object.entries(routes),
       ([key, route]) =>
         Effect.gen(function* () {
-          const routeEntryName = getRouteEntryName(route);
+          const routeEntryName = getRouteEntryBaseName(route, context);
           const { js: jsAssets, css: discoveredCssAssets } =
             getAssetsForChunk(routeEntryName);
           const routeFilePath = resolve(context, route.file);
@@ -571,6 +574,7 @@ function generateReactRouterManifestForDevEffect(
             key,
             createRouteManifestItem({
               route,
+              appDirectory: context,
               assetPrefix,
               jsAssets,
               routeAnalysis,

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -147,6 +147,7 @@ export function registerModifyBrowserManifestAssets(
     options?.manifestChunkNames ??
     getReactRouterManifestChunkNames(
       routes,
+      appDirectory,
       routeChunkOptions?.splitRouteModules
     );
   const isBuild = Boolean(routeChunkOptions?.isBuild);

--- a/src/route-chunks.ts
+++ b/src/route-chunks.ts
@@ -860,6 +860,19 @@ const normalizeRelativeFilePath = (file: string, appDirectory: string) => {
   return normalize(relativePath).split('?')[0];
 };
 
+// An rspack entry name is written out as a path under `output.distPath.js`, so it
+// is a filename, not an identifier. Keep it a safe, app-relative POSIX path: the
+// developer's absolute checkout path must never reach `dist/` (nor the browser
+// manifest), and an entry must never escape the JS output directory. `pathe`
+// already normalizes separators, so only drive prefixes and `..` need handling.
+const toSafeEntryPath = (relativePath: string): string =>
+  relativePath
+    .replace(/^[A-Za-z]:/, '')
+    .split('/')
+    .filter(segment => segment !== '' && segment !== '.')
+    .map(segment => (segment === '..' ? '__' : segment))
+    .join('/');
+
 const isRootRouteModuleId = (config: RouteChunkConfig, id: string) =>
   normalizeRelativeFilePath(id, config.appDirectory) === config.rootRouteFile;
 
@@ -967,7 +980,20 @@ export const validateRouteChunks: (args: {
   );
 };
 
+export const getRouteEntryBaseName = (
+  route: { file: string },
+  appDirectory: string
+): string =>
+  toSafeEntryPath(normalizeRelativeFilePath(route.file, appDirectory)).replace(
+    /\.[^/.]+$/,
+    ''
+  );
+
 export const getRouteChunkEntryName = (
-  routeId: string,
-  chunkName: RouteChunkExportName
-) => `${routeId}-${routeChunkEntrySuffix[chunkName]}`;
+  route: { file: string },
+  chunkName: RouteChunkExportName,
+  appDirectory: string
+): string =>
+  `${getRouteEntryBaseName(route, appDirectory)}-${
+    routeChunkEntrySuffix[chunkName]
+  }`;

--- a/tests/classic-web-route-entries.test.ts
+++ b/tests/classic-web-route-entries.test.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from '@rstest/core';
+import { createClassicWebRouteEntries } from '../src/classic-mode';
+import type { Route } from '../src/types';
+
+const ROUTE_SOURCE = `export async function clientLoader() { return {}; }
+  export default function X() { return null; }`;
+
+/**
+ * Lays out a project whose route module lives *outside* `app/`, which is what a
+ * shared route package or a `relative()` route table produces.
+ */
+const createAppWithOutsideRoute = () => {
+  const root = mkdtempSync(join(tmpdir(), 'rr-entries-'));
+  const appDir = join(root, 'app');
+  const sharedDir = join(root, 'shared');
+  mkdirSync(appDir, { recursive: true });
+  mkdirSync(sharedDir, { recursive: true });
+
+  writeFileSync(
+    join(appDir, 'root.tsx'),
+    `export default function Root() { return null; }`
+  );
+  writeFileSync(join(sharedDir, 'x.tsx'), ROUTE_SOURCE);
+
+  return { root, appDir };
+};
+
+describe('createClassicWebRouteEntries', () => {
+  it('never emits an entry name that escapes the JS output directory', () => {
+    const { root, appDir } = createAppWithOutsideRoute();
+    const routes: Record<string, Route> = {
+      root: { id: 'root', file: 'root.tsx', path: '' },
+      'shared/x': {
+        id: 'shared/x',
+        parentId: 'root',
+        file: '../shared/x.tsx',
+        path: 'x',
+      },
+    };
+
+    try {
+      const { webRouteEntries } = createClassicWebRouteEntries({
+        appDirectory: appDir,
+        isBuild: true,
+        routes,
+        splitRouteModules: true,
+      });
+
+      expect(Object.keys(webRouteEntries).sort()).toEqual([
+        '__/shared/x',
+        '__/shared/x-client-loader',
+        'root',
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('shares one entry between routes that point at the same file', () => {
+    // React Router requires explicit ids when two routes reuse a file. Both
+    // routes import the very same module, and a route chunk is a pure function
+    // of (file, export) — so one entry serves both instead of emitting two
+    // byte-identical chunks.
+    const root = mkdtempSync(join(tmpdir(), 'rr-entries-'));
+    const appDir = join(root, 'app');
+    mkdirSync(join(appDir, 'routes'), { recursive: true });
+    writeFileSync(
+      join(appDir, 'root.tsx'),
+      `export default function Root() { return null; }`
+    );
+    writeFileSync(join(appDir, 'routes', 'shared.tsx'), ROUTE_SOURCE);
+
+    const routes: Record<string, Route> = {
+      root: { id: 'root', file: 'root.tsx', path: '' },
+      a: { id: 'a', parentId: 'root', file: 'routes/shared.tsx', path: 'a' },
+      b: { id: 'b', parentId: 'root', file: 'routes/shared.tsx', path: 'b' },
+    };
+
+    try {
+      const { webRouteEntries } = createClassicWebRouteEntries({
+        appDirectory: appDir,
+        isBuild: true,
+        routes,
+        splitRouteModules: true,
+      });
+
+      expect(Object.keys(webRouteEntries).sort()).toEqual([
+        'root',
+        'routes/shared',
+        'routes/shared-client-loader',
+      ]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/manifest-split-route-modules.test.ts
+++ b/tests/manifest-split-route-modules.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from '@rstest/core';
 import { getReactRouterManifestForDev } from '../src/manifest';
 import {
   getRouteChunkEntryName,
+  getRouteEntryBaseName,
   routeChunkExportNames,
   type RouteChunkExportName,
 } from '../src/route-chunks';
@@ -63,15 +64,17 @@ const routes = {
   },
 };
 
-const createClientStats = (routeId = 'routes/clients') => {
+const clientsRoute = { file: 'routes/clients.tsx' };
+
+const createClientStats = (appDirectory: string, route = clientsRoute) => {
+  const entryName = getRouteEntryBaseName(route, appDirectory);
   const assetsByChunkName: Record<string, string[]> = {
     'entry.client': ['static/js/entry.client.js'],
-    [routeId]: [`static/js/${routeId}.js`],
+    [entryName]: [`static/js/${entryName}.js`],
   };
   for (const exportName of routeChunkExportNames) {
-    assetsByChunkName[getRouteChunkEntryName(routeId, exportName)] = [
-      `static/js/${getRouteChunkEntryName(routeId, exportName)}.js`,
-    ];
+    const chunkName = getRouteChunkEntryName(route, exportName, appDirectory);
+    assetsByChunkName[chunkName] = [`static/js/${chunkName}.js`];
   }
   return { assetsByChunkName };
 };
@@ -81,12 +84,19 @@ const getManifest = async (
   splitRouteModules: boolean | 'enforce',
   isBuild = true
 ) =>
-  getReactRouterManifestForDev(routes, {}, createClientStats(), appDir, '/', {
-    splitRouteModules,
-    rootRouteFile: 'root.tsx',
-    isBuild,
-    cache: new Map(),
-  });
+  getReactRouterManifestForDev(
+    routes,
+    {},
+    createClientStats(appDir),
+    appDir,
+    '/',
+    {
+      splitRouteModules,
+      rootRouteFile: 'root.tsx',
+      isBuild,
+      cache: new Map(),
+    }
+  );
 
 describe('manifest split route modules', () => {
   it.each(routeChunkExportNames)(
@@ -101,7 +111,7 @@ describe('manifest split route modules', () => {
         const field = moduleFieldByExportName[exportName];
 
         expect(manifest.routes['routes/clients'][field]).toBe(
-          `/static/js/${getRouteChunkEntryName('routes/clients', exportName)}.js`
+          `/static/js/${getRouteChunkEntryName(clientsRoute, exportName, appDir)}.js`
         );
       } finally {
         rmSync(root, { recursive: true, force: true });
@@ -118,9 +128,9 @@ describe('manifest split route modules', () => {
       export default function Clients() { return null; }
     `);
     writeFileSync(join(appDir, 'routes/clients.module.css'), '.root {}');
-    const clientStats = createClientStats();
+    const clientStats = createClientStats(appDir);
     clientStats.assetsByChunkName[
-      getRouteChunkEntryName('routes/clients', 'clientLoader')
+      getRouteChunkEntryName(clientsRoute, 'clientLoader', appDir)
     ]?.push('static/css/routes/clients-client-loader.css');
 
     try {
@@ -206,6 +216,105 @@ describe('manifest split route modules', () => {
 
       expect(manifest.routes['routes/clients'].hasClientAction).toBe(true);
       expect(manifest.routes['routes/clients'].clientActionModule).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the app directory out of asset URLs when route ids are absolute', async () => {
+    // `relative(import.meta.dirname)` resolves route files to absolute paths, so
+    // React Router relativizes `file` but derives an *absolute* route id. The id
+    // is an opaque runtime identifier and must never become a filename.
+    const { root, appDir } = createTempApp();
+    const absoluteId = `${appDir}/routes/clients`;
+    const routesWithAbsoluteId = {
+      root: { id: 'root', file: 'root.tsx', path: '' },
+      [absoluteId]: {
+        id: absoluteId,
+        parentId: 'root',
+        file: 'routes/clients.tsx',
+        path: 'clients',
+      },
+    };
+
+    try {
+      const manifest = await getReactRouterManifestForDev(
+        routesWithAbsoluteId,
+        {},
+        createClientStats(appDir),
+        appDir,
+        '/',
+        {
+          splitRouteModules: true,
+          rootRouteFile: 'root.tsx',
+          isBuild: true,
+          cache: new Map(),
+        }
+      );
+      const route = manifest.routes[absoluteId];
+
+      expect(route.clientLoaderModule).toBe(
+        '/static/js/routes/clients-client-loader.js'
+      );
+      expect(route.clientActionModule).toBe(
+        '/static/js/routes/clients-client-action.js'
+      );
+
+      // The route id stays absolute — that is the runtime contract, and changing
+      // it would break `useRouteLoaderData(id)` and `matches[].id`.
+      expect(route.id).toBe(absoluteId);
+
+      // No URL may carry the developer's checkout path, and none may contain the
+      // `static/js//` double slash that an entry name starting with `/` produced.
+      const urls = [
+        route.module,
+        route.clientActionModule,
+        route.clientLoaderModule,
+        route.clientMiddlewareModule,
+        route.hydrateFallbackModule,
+        ...route.imports,
+        ...route.css,
+      ].filter((url): url is string => typeof url === 'string');
+
+      expect(urls.filter(url => url.includes(appDir))).toEqual([]);
+      expect(urls.filter(url => url.includes('static/js//'))).toEqual([]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves routes sharing a file to the same chunk asset', async () => {
+    // React Router requires explicit ids when two routes reuse a file. Both
+    // resolve to one chunk, because a route chunk is a pure function of
+    // (file, export) — previously they produced two byte-identical chunks.
+    const { root, appDir } = createTempApp();
+    const sharedRoutes = {
+      root: { id: 'root', file: 'root.tsx', path: '' },
+      a: { id: 'a', parentId: 'root', file: 'routes/clients.tsx', path: 'a' },
+      b: { id: 'b', parentId: 'root', file: 'routes/clients.tsx', path: 'b' },
+    };
+
+    try {
+      const manifest = await getReactRouterManifestForDev(
+        sharedRoutes,
+        {},
+        createClientStats(appDir),
+        appDir,
+        '/',
+        {
+          splitRouteModules: true,
+          rootRouteFile: 'root.tsx',
+          isBuild: true,
+          cache: new Map(),
+        }
+      );
+
+      expect(manifest.routes.a.clientLoaderModule).toBe(
+        '/static/js/routes/clients-client-loader.js'
+      );
+      expect(manifest.routes.b.clientLoaderModule).toBe(
+        manifest.routes.a.clientLoaderModule
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -223,11 +223,11 @@ describe('manifest', () => {
   });
 
   it('collects only manifest-readable chunk names', () => {
-    expect(Array.from(getReactRouterManifestChunkNames(routes, false))).toEqual(
+    expect(Array.from(getReactRouterManifestChunkNames(routes, '/app', false))).toEqual(
       ['entry.client', 'root', 'routes/page']
     );
 
-    expect(getReactRouterManifestChunkNames(routes, true)).toEqual(
+    expect(getReactRouterManifestChunkNames(routes, '/app', true)).toEqual(
       new Set([
         'entry.client',
         'root',

--- a/tests/react-router-framework/integration/fog-of-war-test.ts
+++ b/tests/react-router-framework/integration/fog-of-war-test.ts
@@ -1196,11 +1196,19 @@ test.describe("Fog of War", () => {
     await app.clickLink("/a");
     await page.waitForSelector("#a");
     expect(await app.getHtml("#a")).toMatch("A LOADER");
-    expect(
-      await page.evaluate(() =>
-        Object.keys((window as any).__reactRouterManifest.routes),
-      ),
-    ).toEqual(["root", "routes/_index", "routes/a"]);
+    // Navigating to /a discovers /a itself. The rendered page also links to
+    // /a/b, and fog-of-war link discovery for that runs on its own debounce, so
+    // depending on timing `routes/a.b` may already be patched in. Assert on the
+    // routes this navigation had to load and on the absence of the 400 dummy
+    // links rather than on an exact snapshot.
+    let manifestRouteIds = await page.evaluate(() =>
+      Object.keys((window as any).__reactRouterManifest.routes),
+    );
+    expect(manifestRouteIds).toEqual(
+      expect.arrayContaining(["root", "routes/_index", "routes/a"]),
+    );
+    expect(manifestRouteIds.filter((id) => id.includes("dummy"))).toEqual([]);
+    expect(manifestRouteIds.length).toBeLessThanOrEqual(4);
   });
 
   test("includes a version query parameter as a cachebuster", async ({

--- a/tests/react-router-framework/integration/helpers/external-site.ts
+++ b/tests/react-router-framework/integration/helpers/external-site.ts
@@ -1,0 +1,21 @@
+import type { Page } from "@playwright/test";
+
+const EXAMPLE_DOMAIN_HTML = `<!doctype html>
+<html>
+  <head><title>Example Domain</title></head>
+  <body><h1>Example Domain</h1></body>
+</html>`;
+
+// Several upstream tests assert that an external redirect lands on
+// https://example.com/. Reaching the real site from CI depends on outbound
+// network access and has aborted runs with net::ERR_ABORTED, so serve a local
+// stand-in that matches what the assertions look for.
+export async function stubExampleDomain(page: Page): Promise<void> {
+  await page.route("https://example.com/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: EXAMPLE_DOMAIN_HTML,
+    }),
+  );
+}

--- a/tests/react-router-framework/integration/route-entry-names-test.ts
+++ b/tests/react-router-framework/integration/route-entry-names-test.ts
@@ -1,0 +1,94 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { test, expect } from "@playwright/test";
+
+import { createProject, build, reactRouterConfig } from "./helpers/rsbuild.js";
+
+const js = String.raw;
+
+// `fs.globSync("**/*")` silently stops short of deeply nested files, which is
+// precisely where a leaked absolute path lands, so walk the tree instead.
+const listEmittedFiles = (cwd: string, dir: string) =>
+  readdirSync(path.join(cwd, dir), { recursive: true })
+    .map(String)
+    .filter((file) => file.endsWith(".js"));
+
+// A route table built with `relative()` resolves route files to absolute paths,
+// so React Router relativizes `file` but derives an *absolute* route id. The id
+// is an opaque runtime identifier; when it is used as an rspack entry name the
+// chunk is written into a directory tree mirroring the developer's checkout and
+// that path is published in the browser manifest.
+test.describe("Route entry names", () => {
+  test("keeps the app directory out of emitted assets and the browser manifest", async () => {
+    let cwd = await createProject({
+      // SPA + framework mode, where this was first observed. SSR shares the very
+      // same route entry construction.
+      "react-router.config.ts": reactRouterConfig({ ssr: false }),
+      "app/routes.ts": js`
+        import type { RouteConfig } from "@react-router/dev/routes";
+        import { relative } from "@react-router/dev/routes";
+
+        const { route } = relative(import.meta.dirname);
+
+        export default [
+          route("customers", "routes/customers.tsx"),
+        ] satisfies RouteConfig;
+      `,
+      "app/routes/customers.tsx": js`
+        export async function clientLoader() {
+          return { name: "Ada" };
+        }
+
+        export default function Customers() {
+          return <h1 data-testid="customers">Customers</h1>;
+        }
+      `,
+    });
+
+    let { status, stderr } = build({ cwd });
+    expect(stderr.toString()).toBe("");
+    expect(status).toBe(0);
+
+    let emitted = listEmittedFiles(cwd, "build/client");
+
+    // An absolute path leaks either verbatim or with its leading separator
+    // swallowed by the `static/js/` join, so check for both shapes.
+    let appDirectory = path.join(cwd, "app");
+    let leaks = [cwd, appDirectory].flatMap((absolute) => [
+      absolute,
+      absolute.replace(/^[/\\]+/, ""),
+    ]);
+    let leaking = (text: string) => leaks.filter((leak) => text.includes(leak));
+
+    expect(emitted.filter((file) => leaking(file).length > 0)).toEqual([]);
+
+    // The route chunk must be a sibling of the route entry itself.
+    expect(emitted).toContain(
+      path.join("static/js/routes/customers-client-loader.js"),
+    );
+
+    let manifestFile = emitted.find((file) =>
+      /static[/\\]js[/\\]manifest-[^/\\]+\.js$/.test(file),
+    );
+    expect(manifestFile).toBeDefined();
+
+    let manifestSource = readFileSync(
+      path.join(cwd, "build/client", manifestFile!),
+      "utf8",
+    );
+    let assetUrls = (manifestSource.match(/['"]\/static\/[^'"]*['"]/g) ?? []).map(
+      (quoted) => quoted.slice(1, -1),
+    );
+    // Guard against a vacuous pass if the manifest format ever changes.
+    expect(assetUrls.length).toBeGreaterThan(0);
+
+    expect(assetUrls.filter((url) => leaking(url).length > 0)).toEqual([]);
+    // An entry name starting with `/` produced a `/static/js//...` double slash.
+    expect(assetUrls.filter((url) => url.includes("//"))).toEqual([]);
+    expect(assetUrls).toContain("/static/js/routes/customers-client-loader.js");
+
+    // The route id itself stays absolute: it is the runtime contract behind
+    // `useRouteLoaderData(id)` and `matches[].id`, and must not be sanitized.
+    expect(manifestSource).toContain(path.join(appDirectory, "routes/customers"));
+  });
+});

--- a/tests/react-router-framework/integration/route-exports-modified-offscreen-test.ts
+++ b/tests/react-router-framework/integration/route-exports-modified-offscreen-test.ts
@@ -76,8 +76,18 @@ test.describe(async () => {
       originalContents = contents;
       return contents.replace(/export const loader.*/, "");
     });
-    // Give the server time to pick the manifest change
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    // Wait until the dev server serves the updated route before reloading.
+    // Upstream sleeps for 200ms here, but on a loaded CI runner the rebuild
+    // can outlast that. The browser would then load the page while the
+    // server build is still the previous one, and React Router's stale-client
+    // check would resync with a document reload of /other on the very next
+    // navigation. A direct document load of a route without a loader hydrates
+    // `null` against a server render of `undefined` (a React Router
+    // inconsistency), which would surface here as an unrelated hydration error.
+    await expect(async () => {
+      let response = await page.request.get(`http://localhost:${port}/other`);
+      expect(await response.text()).not.toContain("hello");
+    }).toPass();
 
     // After browser reload, client should be aware that there's no loader on the other route
     if (browserName === "webkit") {

--- a/tests/react-router-framework/integration/rsc/rsc-nojs-test.ts
+++ b/tests/react-router-framework/integration/rsc/rsc-nojs-test.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 import getPort from "get-port";
 
+import { stubExampleDomain } from "../helpers/external-site.js";
+
 import { implementations, js, setupRscTest, validateRSCHtml } from "./utils";
 
 implementations.forEach((implementation) => {
@@ -237,10 +239,16 @@ implementations.forEach((implementation) => {
         browserName === "firefox",
         "Playwright doesn't like external redirects for tests. It times out waiting for the URL even though it navigates.",
       );
+      await stubExampleDomain(page);
       await page.goto(`http://localhost:${port}/render-redirect`);
       await expect(page.getByText("home")).toBeAttached();
       await page.getByText("External").click();
-      await page.waitForURL(`https://example.com/`);
+      // The RSC error handler assigns `window.location.href` during render and
+      // also commits a `<meta http-equiv="refresh">`, so the browser can start
+      // the external navigation more than once and abort the earlier
+      // attempts. Poll for the final URL instead of latching onto the first
+      // navigation, which `waitForURL` would reject with net::ERR_ABORTED.
+      await expect(page).toHaveURL(`https://example.com/`);
       await expect(page.getByText("Example Domain")).toBeAttached();
     });
 
@@ -272,8 +280,14 @@ implementations.forEach((implementation) => {
         browserName === "firefox",
         "Playwright doesn't like external redirects for tests. It times out waiting for the URL even though it navigates.",
       );
+      await stubExampleDomain(page);
       await page.goto(`http://localhost:${port}/render-redirect/lazy/external`);
-      await page.waitForURL(`https://example.com/`);
+      // The RSC error handler assigns `window.location.href` during render and
+      // also commits a `<meta http-equiv="refresh">`, so the browser can start
+      // the external navigation more than once and abort the earlier
+      // attempts. Poll for the final URL instead of latching onto the first
+      // navigation, which `waitForURL` would reject with net::ERR_ABORTED.
+      await expect(page).toHaveURL(`https://example.com/`);
       await expect(page.getByText("Example Domain")).toBeAttached();
     });
 

--- a/tests/react-router-framework/integration/rsc/rsc-test.ts
+++ b/tests/react-router-framework/integration/rsc/rsc-test.ts
@@ -5,6 +5,8 @@ import {
 } from "@playwright/test";
 import getPort from "get-port";
 
+import { stubExampleDomain } from "../helpers/external-site.js";
+
 import { implementations, js, setupRscTest, validateRSCHtml } from "./utils";
 
 const minifiedServerComponentRenderError =
@@ -1882,10 +1884,16 @@ implementations.forEach((implementation) => {
             browserName === "firefox",
             "Playwright doesn't like external redirects for tests. It times out waiting for the URL even though it navigates.",
           );
+          await stubExampleDomain(page);
           await page.goto(`http://localhost:${port}/render-redirect`);
           await expect(page.getByText("home")).toBeAttached();
           await page.getByText("External").click();
-          await page.waitForURL(`https://example.com/`);
+          // The RSC error handler assigns `window.location.href` during render and
+          // also commits a `<meta http-equiv="refresh">`, so the browser can start
+          // the external navigation more than once and abort the earlier
+          // attempts. Poll for the final URL instead of latching onto the first
+          // navigation, which `waitForURL` would reject with net::ERR_ABORTED.
+          await expect(page).toHaveURL(`https://example.com/`);
           await expect(page.getByText("Example Domain")).toBeAttached();
         });
 
@@ -1921,10 +1929,16 @@ implementations.forEach((implementation) => {
             browserName === "firefox",
             "Playwright doesn't like external redirects for tests. It times out waiting for the URL even though it navigates.",
           );
+          await stubExampleDomain(page);
           await page.goto(`http://localhost:${port}/render-redirect/lazy`);
           await expect(page.getByText("home")).toBeAttached();
           await page.getByText("External").click();
-          await page.waitForURL(`https://example.com/`);
+          // The RSC error handler assigns `window.location.href` during render and
+          // also commits a `<meta http-equiv="refresh">`, so the browser can start
+          // the external navigation more than once and abort the earlier
+          // attempts. Poll for the final URL instead of latching onto the first
+          // navigation, which `waitForURL` would reject with net::ERR_ABORTED.
+          await expect(page).toHaveURL(`https://example.com/`);
           await expect(page.getByText("Example Domain")).toBeAttached();
         });
 
@@ -2062,6 +2076,7 @@ implementations.forEach((implementation) => {
         test("Supports React Server Functions thrown external redirects", async ({
           page,
         }) => {
+          await stubExampleDomain(page);
           await page.goto(
             `http://localhost:${port}/throw-external-redirect-server-action/`,
           );
@@ -2137,6 +2152,7 @@ implementations.forEach((implementation) => {
         test("Supports React Server Functions side-effect external redirects", async ({
           page,
         }) => {
+          await stubExampleDomain(page);
           await page.goto(
             `http://localhost:${port}/side-effect-external-redirect-server-action`,
           );

--- a/tests/route-chunks.test.ts
+++ b/tests/route-chunks.test.ts
@@ -7,6 +7,7 @@ import {
   getRouteChunkIfEnabled,
   getRouteChunkModuleId,
   getRouteChunkNameFromModuleId,
+  getRouteEntryBaseName,
   isRouteChunkModuleId,
   routeChunkExportNames,
   type RouteChunkConfig,
@@ -674,9 +675,13 @@ describe('route chunks', () => {
       expect(
         getRouteChunkNameFromModuleId('/app/routes/r.tsx?route-chunk=not-valid')
       ).toBeNull();
-      expect(getRouteChunkEntryName('routes/clients', 'clientAction')).toBe(
-        'routes/clients-client-action'
-      );
+      expect(
+        getRouteChunkEntryName(
+          { file: 'routes/clients.tsx' },
+          'clientAction',
+          '/app'
+        )
+      ).toBe('routes/clients-client-action');
     });
   });
 
@@ -819,5 +824,46 @@ describe('route chunks', () => {
         /Error splitting route module:[\s\S]*clientAction[\s\S]*clientLoader[\s\S]*These exports[\s\S]*their own chunks[\s\S]*they share/
       );
     });
+  });
+});
+
+describe('route entry names', () => {
+  it('derives the entry base name from the route file', () => {
+    expect(
+      getRouteEntryBaseName(
+        { file: 'domains/customers/routes/customers.tsx' },
+        '/Users/dev/proj/app'
+      )
+    ).toBe('domains/customers/routes/customers');
+  });
+
+  it('keeps the entry name inside the JS output directory', () => {
+    // `relative()` from `@react-router/dev/routes` hands us absolute files.
+    expect(
+      getRouteEntryBaseName(
+        { file: '/Users/dev/proj/app/routes/a.tsx' },
+        '/Users/dev/proj/app'
+      )
+    ).toBe('routes/a');
+
+    // A route outside `appDirectory` must not escape `static/js`.
+    expect(
+      getRouteEntryBaseName({ file: '../shared/x.tsx' }, '/Users/dev/proj/app')
+    ).toBe('__/shared/x');
+
+    // A Windows drive letter is not a legal filename character.
+    expect(
+      getRouteEntryBaseName({ file: 'C:/other/x.tsx' }, 'D:/proj/app')
+    ).toBe('other/x');
+  });
+
+  it('names a route chunk as a sibling of the route entry', () => {
+    expect(
+      getRouteChunkEntryName(
+        { file: 'routes/clients.tsx' },
+        'clientAction',
+        '/Users/dev/proj/app'
+      )
+    ).toBe('routes/clients-client-action');
   });
 });


### PR DESCRIPTION
## Summary

Four changes that close out the open items on the repo after 0.6.0:

- **Relative route entry names** (ports #112 by @alvadorn, fixes the case #114 left open). Route tables built with `relative()` keep an absolute route `id`, and the plugin used that id as the rspack entry name for split route module chunks, so chunks landed under `static/js/<checkout path>/...` and the browser manifest published those paths. Entry and chunk names are now derived from the app-relative route file. Route ids are untouched.
- **Content-derived dev manifest version.** The dev browser manifest used a random `version` per web compilation while the server build stayed pinned to the compilation it was committed with. A web compilation that left the manifest unchanged (the HDR recompile after a server change) made React Router's stale-client check return 204 and reload the document mid-navigation. This is what produced the hydration mismatch failures in `route-exports-modified-offscreen` on main. The dev version now uses the same content hash as production.
- **Framework corpus stabilization** for the three tests that failed the fail-fast ecosystem step on main since 2026-08-29: fog-of-war manifest snapshot race, the offscreen test's fixed 200ms sleep, and the RSC external redirect tests that navigated to the real example.com and latched onto the first of several navigations.
- **Release workflow.** The rstackjs organization does not allow GitHub Actions to create pull requests, so the changesets "Version Packages" PR step fails (see the first Release run on 2026-09-03). The workflow now applies pending changesets directly on the dispatched branch, commits, pushes, and publishes.

## Verification

- `pnpm typecheck`, `pnpm exec rstest run` (all files pass)
- `route-exports-modified-offscreen` under single-core stress (`taskset -c 0`, 24 repeats × 6 workers): 5 failures before the manifest version fix, 0 after
- fog-of-war "URL gets too large" × 8 and the six external redirect tests × 3 under the same stress: all pass
- `hmr-hdr-test`, `fog-of-war-test`, `route-exports-modified-offscreen-test`, `route-entry-names-test`, `split-route-modules-test` locally: 38 passed

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
