### PR TITLE
perf: shrink classic production browser output

### DIFF
--- a/.changeset/classic-production-output-size.md
+++ b/.changeset/classic-production-output-size.md
@@ -1,0 +1,14 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Shrink classic-mode production browser output. Production builds now mangle
+export names (`optimization.mangleExports: 'size'`), drop exports nothing
+imports across the whole graph (`optimization.usedExports: 'global'`), and name
+async chunks `static/js/async/[id]-[contenthash:16].js`. Classic mode resolves
+route modules through the browser manifest by chunk, so export names are not
+part of its runtime contract. RSC builds are unchanged and keep every export
+name because Flight resolves client references by name. Development builds are
+unchanged. To keep readable export names in a classic production build, set
+`optimization.mangleExports` and `optimization.usedExports` back in the
+function form of `tools.rspack`, which runs after plugin defaults are merged.

--- a/src/mode-plan.ts
+++ b/src/mode-plan.ts
@@ -345,10 +345,20 @@ const createClassicModePlan = async ({
       wasmLoading: 'fetch',
       library: { type: 'module' },
       module: true,
+      // Async chunks are addressed by id at runtime, so the chunk name only
+      // adds bytes to the filename and to every place that references it.
+      ...(isBuild
+        ? { chunkFilename: 'static/js/async/[id]-[contenthash:16].js' }
+        : {}),
     },
     webOptimization: {
       avoidEntryIife: true,
       runtimeChunk: 'single',
+      // Classic mode resolves route modules through the browser manifest by
+      // chunk, not by export name, so production builds can mangle export
+      // names and drop exports nothing imports across the whole graph. RSC
+      // mode must keep every export name; see createRscModePlan.
+      ...(isBuild ? { mangleExports: 'size', usedExports: 'global' } : {}),
     },
     nodeExternals: Array.from(
       new Set(['express', ...getSsrExternals(process.cwd())])

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -445,6 +445,43 @@ describe('pluginReactRouter', () => {
     ).toBeUndefined();
   });
 
+  it('shrinks classic production browser output', async () => {
+    const rsbuild = await createStubRsbuild({
+      action: 'build',
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.environments.web.tools.rspack.optimization).toMatchObject({
+      mangleExports: 'size',
+      usedExports: 'global',
+    });
+    expect(config.environments.web.tools.rspack.output.chunkFilename).toBe(
+      'static/js/async/[id]-[contenthash:16].js'
+    );
+  });
+
+  it('keeps classic development export names and chunk names', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(
+      config.environments.web.tools.rspack.optimization.mangleExports
+    ).toBeUndefined();
+    expect(
+      config.environments.web.tools.rspack.optimization.usedExports
+    ).toBeUndefined();
+    expect(
+      config.environments.web.tools.rspack.output.chunkFilename
+    ).toBeUndefined();
+  });
+
   it('preserves production export names for RSC builds', async () => {
     const rsbuild = await createStubRsbuild({
       action: 'build',


### PR DESCRIPTION
## Summary

Revives the classic-mode half of #85, which was closed pending the React Router 8 work. Classic production builds now set:

- `optimization.mangleExports: 'size'`
- `optimization.usedExports: 'global'`
- `output.chunkFilename: 'static/js/async/[id]-[contenthash:16].js'`

Classic mode resolves route modules through the browser manifest by chunk, so export names are not part of its runtime contract. RSC mode is untouched and keeps `mangleExports: false` / `usedExports: false`, because Flight resolves client references by export name. Development builds are unchanged.

Users who want readable export names in a classic production build can set the two optimization flags back in the function form of `tools.rspack`, which runs after plugin defaults are merged.

## Measured

Gzipped client JS, built from this branch versus 0.6.1:

| Example | Before | After | Delta |
|---|---:|---:|---:|
| default-template | 111.0 kB | 110.4 kB | -0.5% |
| epic-stack (client output) | 336.1 kB | 332.1 kB | -1.2% |

Smaller than #85's synthetic numbers, which is expected: the synthetic fixtures had far more routes and re-exports to mangle. The epic-stack example's node build fails on `main` for an unrelated reason, so only its emitted client output was measured.

## Verification

- `pnpm typecheck`, `pnpm exec rstest run` (all files pass)
- New `tests/index.test.ts` cases: classic build enables the flags and chunk filename, classic dev leaves them undefined, RSC build still disables mangling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
