### PR TITLE
fix: generate the Prisma client in the epic-stack example build

### DIFF
--- a/examples/epic-stack/package.json
+++ b/examples/epic-stack/package.json
@@ -10,7 +10,7 @@
     "#tests/*": "./tests/*"
   },
   "scripts": {
-    "build": "run-s build:*",
+    "build": "prisma generate && run-s build:*",
     "build:icons": "tsx ./other/build-icons.ts",
     "build:remix": "rsbuild build",
     "build:server": "tsx ./other/build-server.ts",


### PR DESCRIPTION
## Summary

`pnpm build` in `examples/epic-stack` failed on a fresh checkout with `Can't resolve '.prisma/client/default'`. The generated Prisma client only exists after `prisma generate`, which upstream Epic Stack runs from its `setup` script. Run it as the first step of `build` so the example builds on its own.

Every other example (`client-only`, `cloudflare`, `custom-node-server`, `default-template`, `federation`, `prerender`, `react-router-8`, `rsc-mode`, `spa-mode`) builds cleanly on current `main`; epic-stack was the only failure.

## Verification

Removed the generated client, then `pnpm build` in `examples/epic-stack`: `prisma generate`, `build:icons`, `build:remix` (web and node), and `build:server` all complete with exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
