### PR TITLE
refactor: simplify recent route entry, manifest, and test changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         default: 'main'
         type: string
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency: ${{ github.workflow }}-${{ inputs.branch }}
 
 permissions:
   contents: write
@@ -55,23 +55,17 @@ jobs:
       # instead: bump the version, write the changelog, commit, and push. The
       # publish step below then runs against a tree with no pending changesets.
       - name: Apply pending changesets
-        id: version
         run: |
-          pending="$(find .changeset -maxdepth 1 -name '*.md' ! -name 'README.md' | wc -l)"
-          if [ "$pending" = "0" ]; then
+          pnpm changeset version
+          if git diff --quiet; then
             echo "No pending changesets; publishing current version."
-            echo "versioned=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          pnpm changeset version
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
-          version="$(node -p "require('./package.json').version")"
-          git commit -m "chore: version packages (${version})"
-          git push origin "HEAD:${{ github.event.inputs.branch || github.ref_name }}"
-          echo "versioned=true" >> "$GITHUB_OUTPUT"
-          echo "Versioned to ${version}"
+          git commit -m "chore: version packages ($(node -p "require('./package.json').version"))"
+          git push origin "HEAD:${{ inputs.branch }}"
 
       - name: Publish to npm
         id: changesets
@@ -79,7 +73,6 @@ jobs:
         with:
           # Run our custom release script that builds and publishes
           publish: pnpm release
-          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/classic-mode.ts
+++ b/src/classic-mode.ts
@@ -167,11 +167,7 @@ export const createClassicWebRouteEntries = ({
           if (!source.includes(exportName)) {
             continue;
           }
-          const chunkEntryName = getRouteChunkEntryName(
-            route,
-            exportName,
-            appDirectory
-          );
+          const chunkEntryName = getRouteChunkEntryName(entryName, exportName);
           manifestChunkNames.add(chunkEntryName);
           acc[chunkEntryName] = {
             import: getRouteChunkModuleId(routeFilePath, exportName),

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -413,26 +413,6 @@ export const getReactRouterManifestPath = ({
   return `${dir}/manifest-${version}.js`;
 };
 
-// The version is derived from the manifest content in every mode. React
-// Router's stale-client detection compares the version the browser loaded with
-// the one the server build was pinned to, and answers a mismatch with a
-// document reload. In development the browser manifest asset is served from
-// the latest web compilation while the server build stays pinned to the
-// compilation it was committed with, so a random per-compilation version made
-// the two disagree whenever a web compilation completed without changing the
-// manifest (for example the hot data revalidation recompile that follows a
-// server change), reloading the document for no reason. Equal content now
-// yields an equal version, and a real manifest change still busts the browser
-// cache through the `?v=` query on the development manifest URL.
-const getManifestVersion = (fingerprintedValues: {
-  entry: unknown;
-  routes: unknown;
-}): string =>
-  createHash('md5')
-    .update(JSON.stringify(fingerprintedValues))
-    .digest('hex')
-    .slice(0, 8);
-
 export const getReactRouterManifestChunkNames = (
   routes: Record<string, Route>,
   appDirectory: string,
@@ -440,12 +420,13 @@ export const getReactRouterManifestChunkNames = (
 ): Set<string> => {
   const chunkNames = new Set<string>(['entry.client']);
   for (const route of Object.values(routes)) {
-    chunkNames.add(getRouteEntryBaseName(route, appDirectory));
+    const routeEntryName = getRouteEntryBaseName(route, appDirectory);
+    chunkNames.add(routeEntryName);
     if (!splitRouteModules || route.id === 'root') {
       continue;
     }
     for (const exportName of routeChunkExportNames) {
-      chunkNames.add(getRouteChunkEntryName(route, exportName, appDirectory));
+      chunkNames.add(getRouteChunkEntryName(routeEntryName, exportName));
     }
   }
   return chunkNames;
@@ -453,7 +434,7 @@ export const getReactRouterManifestChunkNames = (
 
 const createRouteManifestItem = ({
   route,
-  appDirectory,
+  routeEntryName,
   assetPrefix,
   jsAssets,
   routeAnalysis,
@@ -461,7 +442,7 @@ const createRouteManifestItem = ({
   getCssAssetsForChunk,
 }: {
   route: Route;
-  appDirectory: string;
+  routeEntryName: string;
   assetPrefix: string;
   jsAssets: string[];
   routeAnalysis: RouteManifestAnalysis;
@@ -469,21 +450,20 @@ const createRouteManifestItem = ({
   getCssAssetsForChunk: (chunkName: string) => string[];
 }): RouteManifestItem => {
   const routeChunkMap = routeAnalysis.hasRouteChunkByExportName;
-  const chunkModulePath = (exportName: RouteChunkExportName) =>
+  const chunkEntryName = (exportName: RouteChunkExportName) =>
     routeChunkMap?.[exportName]
-      ? getModulePathForChunk(
-          getRouteChunkEntryName(route, exportName, appDirectory)
-        )
+      ? getRouteChunkEntryName(routeEntryName, exportName)
       : undefined;
+  const chunkModulePath = (exportName: RouteChunkExportName) => {
+    const name = chunkEntryName(exportName);
+    return name ? getModulePathForChunk(name) : undefined;
+  };
   const cssAssets = [
     ...routeAnalysis.cssAssets,
-    ...routeChunkExportNames.flatMap(exportName =>
-      routeChunkMap?.[exportName]
-        ? getCssAssetsForChunk(
-            getRouteChunkEntryName(route, exportName, appDirectory)
-          )
-        : []
-    ),
+    ...routeChunkExportNames.flatMap(exportName => {
+      const name = chunkEntryName(exportName);
+      return name ? getCssAssetsForChunk(name) : [];
+    }),
   ];
 
   return {
@@ -581,7 +561,7 @@ function generateReactRouterManifestForDevEffect(
             key,
             createRouteManifestItem({
               route,
-              appDirectory: context,
+              routeEntryName,
               assetPrefix,
               jsAssets,
               routeAnalysis,
@@ -625,7 +605,14 @@ function generateReactRouterManifestForDevEffect(
       },
       routes: result,
     };
-    const version = getManifestVersion(fingerprintedValues);
+    // Content-derived in development too. React Router's stale-client check
+    // compares the browser's manifest version with the pinned server build's,
+    // and a random per-compilation version made unchanged manifests differ
+    // whenever a web compilation completed without a new server pin.
+    const version = createHash('md5')
+      .update(JSON.stringify(fingerprintedValues))
+      .digest('hex')
+      .slice(0, 8);
     const manifestPath = getReactRouterManifestPath({
       version,
       isBuild,

--- a/src/route-chunks.ts
+++ b/src/route-chunks.ts
@@ -7,6 +7,7 @@ import { print } from 'yuku-codegen';
 import { walk } from 'yuku-parser';
 import { dirname, normalize, relative, resolve } from 'pathe';
 import { SERVER_ONLY_ROUTE_EXPORTS_SET } from './constants.js';
+import { createRouteId } from './plugin-utils.js';
 
 type AnyNode = Record<string, any>;
 
@@ -984,16 +985,11 @@ export const getRouteEntryBaseName = (
   route: { file: string },
   appDirectory: string
 ): string =>
-  toSafeEntryPath(normalizeRelativeFilePath(route.file, appDirectory)).replace(
-    /\.[^/.]+$/,
-    ''
+  createRouteId(
+    toSafeEntryPath(normalizeRelativeFilePath(route.file, appDirectory))
   );
 
 export const getRouteChunkEntryName = (
-  route: { file: string },
-  chunkName: RouteChunkExportName,
-  appDirectory: string
-): string =>
-  `${getRouteEntryBaseName(route, appDirectory)}-${
-    routeChunkEntrySuffix[chunkName]
-  }`;
+  routeEntryBaseName: string,
+  chunkName: RouteChunkExportName
+): string => `${routeEntryBaseName}-${routeChunkEntrySuffix[chunkName]}`;

--- a/tests/classic-web-route-entries.test.ts
+++ b/tests/classic-web-route-entries.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { describe, expect, it } from '@rstest/core';
 import { createClassicWebRouteEntries } from '../src/classic-mode';
 import type { Route } from '../src/types';
@@ -8,29 +8,26 @@ import type { Route } from '../src/types';
 const ROUTE_SOURCE = `export async function clientLoader() { return {}; }
   export default function X() { return null; }`;
 
-/**
- * Lays out a project whose route module lives *outside* `app/`, which is what a
- * shared route package or a `relative()` route table produces.
- */
-const createAppWithOutsideRoute = () => {
+/** Lays out `app/root.tsx` plus the given files, keyed by path under the project root. */
+const createApp = (files: Record<string, string>) => {
   const root = mkdtempSync(join(tmpdir(), 'rr-entries-'));
   const appDir = join(root, 'app');
-  const sharedDir = join(root, 'shared');
-  mkdirSync(appDir, { recursive: true });
-  mkdirSync(sharedDir, { recursive: true });
-
-  writeFileSync(
-    join(appDir, 'root.tsx'),
-    `export default function Root() { return null; }`
-  );
-  writeFileSync(join(sharedDir, 'x.tsx'), ROUTE_SOURCE);
-
+  const allFiles = {
+    'app/root.tsx': `export default function Root() { return null; }`,
+    ...files,
+  };
+  for (const [file, source] of Object.entries(allFiles)) {
+    mkdirSync(dirname(join(root, file)), { recursive: true });
+    writeFileSync(join(root, file), source);
+  }
   return { root, appDir };
 };
 
 describe('createClassicWebRouteEntries', () => {
   it('never emits an entry name that escapes the JS output directory', () => {
-    const { root, appDir } = createAppWithOutsideRoute();
+    // A shared route package or a `relative()` route table produces a route
+    // module that lives outside `app/`.
+    const { root, appDir } = createApp({ 'shared/x.tsx': ROUTE_SOURCE });
     const routes: Record<string, Route> = {
       root: { id: 'root', file: 'root.tsx', path: '' },
       'shared/x': {
@@ -64,14 +61,7 @@ describe('createClassicWebRouteEntries', () => {
     // routes import the very same module, and a route chunk is a pure function
     // of (file, export) — so one entry serves both instead of emitting two
     // byte-identical chunks.
-    const root = mkdtempSync(join(tmpdir(), 'rr-entries-'));
-    const appDir = join(root, 'app');
-    mkdirSync(join(appDir, 'routes'), { recursive: true });
-    writeFileSync(
-      join(appDir, 'root.tsx'),
-      `export default function Root() { return null; }`
-    );
-    writeFileSync(join(appDir, 'routes', 'shared.tsx'), ROUTE_SOURCE);
+    const { root, appDir } = createApp({ 'app/routes/shared.tsx': ROUTE_SOURCE });
 
     const routes: Record<string, Route> = {
       root: { id: 'root', file: 'root.tsx', path: '' },

--- a/tests/manifest-split-route-modules.test.ts
+++ b/tests/manifest-split-route-modules.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from '@rstest/core';
 import { getReactRouterManifestForDev } from '../src/manifest';
+import type { Route } from '../src/types';
 import {
   getRouteChunkEntryName,
   getRouteEntryBaseName,
@@ -66,14 +67,23 @@ const routes = {
 
 const clientsRoute = { file: 'routes/clients.tsx' };
 
-const createClientStats = (appDirectory: string, route = clientsRoute) => {
-  const entryName = getRouteEntryBaseName(route, appDirectory);
+const clientsChunkName = (
+  appDirectory: string,
+  exportName: RouteChunkExportName
+) =>
+  getRouteChunkEntryName(
+    getRouteEntryBaseName(clientsRoute, appDirectory),
+    exportName
+  );
+
+const createClientStats = (appDirectory: string) => {
+  const entryName = getRouteEntryBaseName(clientsRoute, appDirectory);
   const assetsByChunkName: Record<string, string[]> = {
     'entry.client': ['static/js/entry.client.js'],
     [entryName]: [`static/js/${entryName}.js`],
   };
   for (const exportName of routeChunkExportNames) {
-    const chunkName = getRouteChunkEntryName(route, exportName, appDirectory);
+    const chunkName = clientsChunkName(appDirectory, exportName);
     assetsByChunkName[chunkName] = [`static/js/${chunkName}.js`];
   }
   return { assetsByChunkName };
@@ -82,10 +92,11 @@ const createClientStats = (appDirectory: string, route = clientsRoute) => {
 const getManifest = async (
   appDir: string,
   splitRouteModules: boolean | 'enforce',
-  isBuild = true
+  isBuild = true,
+  routeTable: Record<string, Route> = routes
 ) =>
   getReactRouterManifestForDev(
-    routes,
+    routeTable,
     {},
     createClientStats(appDir),
     appDir,
@@ -111,7 +122,7 @@ describe('manifest split route modules', () => {
         const field = moduleFieldByExportName[exportName];
 
         expect(manifest.routes['routes/clients'][field]).toBe(
-          `/static/js/${getRouteChunkEntryName(clientsRoute, exportName, appDir)}.js`
+          `/static/js/${clientsChunkName(appDir, exportName)}.js`
         );
       } finally {
         rmSync(root, { recursive: true, force: true });
@@ -130,7 +141,7 @@ describe('manifest split route modules', () => {
     writeFileSync(join(appDir, 'routes/clients.module.css'), '.root {}');
     const clientStats = createClientStats(appDir);
     clientStats.assetsByChunkName[
-      getRouteChunkEntryName(clientsRoute, 'clientLoader', appDir)
+      clientsChunkName(appDir, 'clientLoader')
     ]?.push('static/css/routes/clients-client-loader.css');
 
     try {
@@ -238,19 +249,7 @@ describe('manifest split route modules', () => {
     };
 
     try {
-      const manifest = await getReactRouterManifestForDev(
-        routesWithAbsoluteId,
-        {},
-        createClientStats(appDir),
-        appDir,
-        '/',
-        {
-          splitRouteModules: true,
-          rootRouteFile: 'root.tsx',
-          isBuild: true,
-          cache: new Map(),
-        }
-      );
+      const manifest = await getManifest(appDir, true, true, routesWithAbsoluteId);
       const route = manifest.routes[absoluteId];
 
       expect(route.clientLoaderModule).toBe(
@@ -295,19 +294,7 @@ describe('manifest split route modules', () => {
     };
 
     try {
-      const manifest = await getReactRouterManifestForDev(
-        sharedRoutes,
-        {},
-        createClientStats(appDir),
-        appDir,
-        '/',
-        {
-          splitRouteModules: true,
-          rootRouteFile: 'root.tsx',
-          isBuild: true,
-          cache: new Map(),
-        }
-      );
+      const manifest = await getManifest(appDir, true, true, sharedRoutes);
 
       expect(manifest.routes.a.clientLoaderModule).toBe(
         '/static/js/routes/clients-client-loader.js'

--- a/tests/react-router-framework/integration/fog-of-war-test.ts
+++ b/tests/react-router-framework/integration/fog-of-war-test.ts
@@ -1207,8 +1207,9 @@ test.describe("Fog of War", () => {
     expect(manifestRouteIds).toEqual(
       expect.arrayContaining(["root", "routes/_index", "routes/a"]),
     );
-    expect(manifestRouteIds.filter((id) => id.includes("dummy"))).toEqual([]);
-    expect(manifestRouteIds.length).toBeLessThanOrEqual(4);
+    for (let id of manifestRouteIds) {
+      expect(["root", "routes/_index", "routes/a", "routes/a.b"]).toContain(id);
+    }
   });
 
   test("includes a version query parameter as a cachebuster", async ({

--- a/tests/react-router-framework/integration/helpers/external-site.ts
+++ b/tests/react-router-framework/integration/helpers/external-site.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 const EXAMPLE_DOMAIN_HTML = `<!doctype html>
 <html>
@@ -18,4 +18,14 @@ export async function stubExampleDomain(page: Page): Promise<void> {
       body: EXAMPLE_DOMAIN_HTML,
     }),
   );
+}
+
+// The RSC error handler assigns `window.location.href` during render and also
+// commits a `<meta http-equiv="refresh">`, so the browser can start the
+// external navigation more than once and abort the earlier attempts. Poll for
+// the final URL instead of latching onto the first navigation, which
+// `waitForURL` would reject with net::ERR_ABORTED.
+export async function expectExternalRedirect(page: Page): Promise<void> {
+  await expect(page).toHaveURL("https://example.com/");
+  await expect(page.getByText("Example Domain")).toBeAttached();
 }

--- a/tests/react-router-framework/integration/route-entry-names-test.ts
+++ b/tests/react-router-framework/integration/route-entry-names-test.ts
@@ -2,12 +2,10 @@ import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { test, expect } from "@playwright/test";
 
+import { js } from "./helpers/create-fixture.js";
 import { createProject, build, reactRouterConfig } from "./helpers/rsbuild.js";
 
-const js = String.raw;
-
-// `fs.globSync("**/*")` silently stops short of deeply nested files, which is
-// precisely where a leaked absolute path lands, so walk the tree instead.
+// Walk the tree rather than glob: a leaked absolute path lands deeply nested.
 const listEmittedFiles = (cwd: string, dir: string) =>
   readdirSync(path.join(cwd, dir), { recursive: true })
     .map(String)
@@ -52,20 +50,14 @@ test.describe("Route entry names", () => {
     let emitted = listEmittedFiles(cwd, "build/client");
 
     // An absolute path leaks either verbatim or with its leading separator
-    // swallowed by the `static/js/` join, so check for both shapes.
+    // swallowed by the `static/js/` join; the stripped form matches both.
     let appDirectory = path.join(cwd, "app");
-    let leaks = [cwd, appDirectory].flatMap((absolute) => [
-      absolute,
-      absolute.replace(/^[/\\]+/, ""),
-    ]);
-    let leaking = (text: string) => leaks.filter((leak) => text.includes(leak));
+    let leaking = (text: string) => text.includes(cwd.replace(/^[/\\]+/, ""));
 
-    expect(emitted.filter((file) => leaking(file).length > 0)).toEqual([]);
+    expect(emitted.filter(leaking)).toEqual([]);
 
     // The route chunk must be a sibling of the route entry itself.
-    expect(emitted).toContain(
-      path.join("static/js/routes/customers-client-loader.js"),
-    );
+    expect(emitted).toContain("static/js/routes/customers-client-loader.js");
 
     let manifestFile = emitted.find((file) =>
       /static[/\\]js[/\\]manifest-[^/\\]+\.js$/.test(file),
@@ -82,7 +74,7 @@ test.describe("Route entry names", () => {
     // Guard against a vacuous pass if the manifest format ever changes.
     expect(assetUrls.length).toBeGreaterThan(0);
 
-    expect(assetUrls.filter((url) => leaking(url).length > 0)).toEqual([]);
+    expect(assetUrls.filter(leaking)).toEqual([]);
     // An entry name starting with `/` produced a `/static/js//...` double slash.
     expect(assetUrls.filter((url) => url.includes("//"))).toEqual([]);
     expect(assetUrls).toContain("/static/js/routes/customers-client-loader.js");

--- a/tests/react-router-framework/integration/rsc/rsc-nojs-test.ts
+++ b/tests/react-router-framework/integration/rsc/rsc-nojs-test.ts
@@ -1,7 +1,10 @@
 import { test, expect } from "@playwright/test";
 import getPort from "get-port";
 
-import { stubExampleDomain } from "../helpers/external-site.js";
+import {
+  expectExternalRedirect,
+  stubExampleDomain,
+} from "../helpers/external-site.js";
 
 import { implementations, js, setupRscTest, validateRSCHtml } from "./utils";
 
@@ -243,13 +246,7 @@ implementations.forEach((implementation) => {
       await page.goto(`http://localhost:${port}/render-redirect`);
       await expect(page.getByText("home")).toBeAttached();
       await page.getByText("External").click();
-      // The RSC error handler assigns `window.location.href` during render and
-      // also commits a `<meta http-equiv="refresh">`, so the browser can start
-      // the external navigation more than once and abort the earlier
-      // attempts. Poll for the final URL instead of latching onto the first
-      // navigation, which `waitForURL` would reject with net::ERR_ABORTED.
-      await expect(page).toHaveURL(`https://example.com/`);
-      await expect(page.getByText("Example Domain")).toBeAttached();
+      await expectExternalRedirect(page);
     });
 
     test("Handles unsupported protocol redirect Responses from render", async ({
@@ -282,13 +279,7 @@ implementations.forEach((implementation) => {
       );
       await stubExampleDomain(page);
       await page.goto(`http://localhost:${port}/render-redirect/lazy/external`);
-      // The RSC error handler assigns `window.location.href` during render and
-      // also commits a `<meta http-equiv="refresh">`, so the browser can start
-      // the external navigation more than once and abort the earlier
-      // attempts. Poll for the final URL instead of latching onto the first
-      // navigation, which `waitForURL` would reject with net::ERR_ABORTED.
-      await expect(page).toHaveURL(`https://example.com/`);
-      await expect(page.getByText("Example Domain")).toBeAttached();
+      await expectExternalRedirect(page);
     });
 
     test("Handles unsupported protocol redirect Responses from suspended render", async ({

--- a/tests/react-router-framework/integration/rsc/rsc-test.ts
+++ b/tests/react-router-framework/integration/rsc/rsc-test.ts
@@ -5,7 +5,10 @@ import {
 } from "@playwright/test";
 import getPort from "get-port";
 
-import { stubExampleDomain } from "../helpers/external-site.js";
+import {
+  expectExternalRedirect,
+  stubExampleDomain,
+} from "../helpers/external-site.js";
 
 import { implementations, js, setupRscTest, validateRSCHtml } from "./utils";
 
@@ -1888,13 +1891,7 @@ implementations.forEach((implementation) => {
           await page.goto(`http://localhost:${port}/render-redirect`);
           await expect(page.getByText("home")).toBeAttached();
           await page.getByText("External").click();
-          // The RSC error handler assigns `window.location.href` during render and
-          // also commits a `<meta http-equiv="refresh">`, so the browser can start
-          // the external navigation more than once and abort the earlier
-          // attempts. Poll for the final URL instead of latching onto the first
-          // navigation, which `waitForURL` would reject with net::ERR_ABORTED.
-          await expect(page).toHaveURL(`https://example.com/`);
-          await expect(page.getByText("Example Domain")).toBeAttached();
+          await expectExternalRedirect(page);
         });
 
         test("Handles unsupported protocol redirect Responses from render", async ({
@@ -1933,13 +1930,7 @@ implementations.forEach((implementation) => {
           await page.goto(`http://localhost:${port}/render-redirect/lazy`);
           await expect(page.getByText("home")).toBeAttached();
           await page.getByText("External").click();
-          // The RSC error handler assigns `window.location.href` during render and
-          // also commits a `<meta http-equiv="refresh">`, so the browser can start
-          // the external navigation more than once and abort the earlier
-          // attempts. Poll for the final URL instead of latching onto the first
-          // navigation, which `waitForURL` would reject with net::ERR_ABORTED.
-          await expect(page).toHaveURL(`https://example.com/`);
-          await expect(page.getByText("Example Domain")).toBeAttached();
+          await expectExternalRedirect(page);
         });
 
         test("Handles unsupported protocol redirect Responses from suspended render", async ({

--- a/tests/route-chunks.test.ts
+++ b/tests/route-chunks.test.ts
@@ -675,13 +675,9 @@ describe('route chunks', () => {
       expect(
         getRouteChunkNameFromModuleId('/app/routes/r.tsx?route-chunk=not-valid')
       ).toBeNull();
-      expect(
-        getRouteChunkEntryName(
-          { file: 'routes/clients.tsx' },
-          'clientAction',
-          '/app'
-        )
-      ).toBe('routes/clients-client-action');
+      expect(getRouteChunkEntryName('routes/clients', 'clientAction')).toBe(
+        'routes/clients-client-action'
+      );
     });
   });
 
@@ -858,12 +854,12 @@ describe('route entry names', () => {
   });
 
   it('names a route chunk as a sibling of the route entry', () => {
-    expect(
-      getRouteChunkEntryName(
-        { file: 'routes/clients.tsx' },
-        'clientAction',
-        '/Users/dev/proj/app'
-      )
-    ).toBe('routes/clients-client-action');
+    const entryName = getRouteEntryBaseName(
+      { file: 'routes/clients.tsx' },
+      '/Users/dev/proj/app'
+    );
+    expect(getRouteChunkEntryName(entryName, 'clientAction')).toBe(
+      'routes/clients-client-action'
+    );
   });
 });


### PR DESCRIPTION
## Summary

Cleanup pass over everything merged since 0.6.0 (four parallel reviews for reuse, simplification, efficiency, and altitude). No behavior change and no changeset.

- `getRouteChunkEntryName` now takes the already-derived entry base name instead of re-resolving the route file per export (the dev manifest regenerates on every web compilation, so this removed up to three redundant path resolutions per route), and `getRouteEntryBaseName` reuses `createRouteId`. `createRouteManifestItem` no longer needs `appDirectory`.
- The one-line dev manifest version hash is inlined with a shorter comment.
- Release workflow: unused step outputs and the unreachable `github.ref_name` fallback are gone, `changeset version` plus `git diff --quiet` decides whether there is anything to commit, and concurrency is keyed on the branch input the run checks out.
- Tests: one `expectExternalRedirect` helper replaces four copies of the same comment and assertions; fog-of-war asserts the allowed route id set instead of `length <= 4`; the split-route-module tests reuse `getManifest` via a route table parameter; the classic entries test has a single fixture helper; `route-entry-names-test` imports the shared `js` tag and drops a redundant leak matcher.

Skipped on purpose: the `'..' -> '__'` entry segment mapping (a collision needs a real directory literally named `__`), serving the pinned manifest from the dev server (a deeper change than this pass), and making plugin optimization defaults overridable via object-form `tools.rspack` (pre-existing design shared by every key).

## Verification

`pnpm typecheck`, `pnpm build`, `pnpm exec rstest run`, Prettier across src/tests/workflow, and the touched corpus tests (external redirect ×6, fog-of-war URL limit, route entry names) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
