### PR TITLE
fix: guard entry-name collisions and pass resolved future to buildEnd

### DIFF
--- a/.changeset/entry-name-collisions-and-build-end-future.md
+++ b/.changeset/entry-name-collisions-and-build-end-future.md
@@ -1,0 +1,10 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Fail the build with a clear error when two different route files sanitize to
+the same rspack entry name (for example `../shared/x.tsx` and `__/shared/x.tsx`)
+instead of letting one route silently serve the other's module. Routes that
+intentionally share a file still share one entry. `buildEnd` hooks now receive
+the fully resolved `future` flags, including defaults, rather than only the
+flags the user or a preset set explicitly.

--- a/src/classic-mode.ts
+++ b/src/classic-mode.ts
@@ -143,10 +143,26 @@ export const createClassicWebRouteEntries = ({
   webRouteEntries: Record<string, RsbuildEntryDescription>;
 } => {
   const manifestChunkNames = new Set<string>(['entry.client']);
+  // Entry names are sanitized paths, so two distinct route files could in
+  // principle map to one name (for example `../shared/x.tsx` and
+  // `__/shared/x.tsx`). Refuse that instead of letting one route silently
+  // serve the other's module. Routes that share a file intentionally share
+  // an entry.
+  const routeFileByEntryName = new Map<string, string>();
   const webRouteEntries = Object.values(routes).reduce(
     (acc, route) => {
       const entryName = getRouteEntryBaseName(route, appDirectory);
       const routeFilePath = resolve(appDirectory, route.file);
+      const existingRouteFile = routeFileByEntryName.get(entryName);
+      if (
+        existingRouteFile !== undefined &&
+        existingRouteFile !== routeFilePath
+      ) {
+        throw new Error(
+          `[rsbuild-plugin-react-router] Route files ${JSON.stringify(existingRouteFile)} and ${JSON.stringify(routeFilePath)} both resolve to the entry name ${JSON.stringify(entryName)}. Rename one of them so their paths relative to the app directory differ.`
+        );
+      }
+      routeFileByEntryName.set(entryName, routeFilePath);
       manifestChunkNames.add(entryName);
       acc[entryName] = {
         import: `${routeFilePath}${BUILD_CLIENT_ROUTE_QUERY_STRING}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,7 +263,6 @@ export const pluginReactRouter = (
 
     const {
       resolved: resolvedConfig,
-      userAndPresetConfig,
       presets: configPresets,
       hasConfiguredServerModuleFormat,
     } = await effectRuntime.runPromise(
@@ -472,10 +471,7 @@ export const pluginReactRouter = (
           resolvedConfigForPreset as ReactRouterPresetResolvedConfig,
       });
     }
-    const buildEndReactRouterConfig: ResolvedReactRouterConfig = {
-      ...resolvedConfigWithRoutes,
-      future: userAndPresetConfig.future ?? {},
-    } as ResolvedReactRouterConfig;
+    const buildEndReactRouterConfig = resolvedConfigWithRoutes;
 
     const isBuild = api.context.action === 'build';
     if (!isBuild) {

--- a/tests/classic-web-route-entries.test.ts
+++ b/tests/classic-web-route-entries.test.ts
@@ -56,6 +56,41 @@ describe('createClassicWebRouteEntries', () => {
     }
   });
 
+  it('refuses two different route files that sanitize to one entry name', () => {
+    const { root, appDir } = createApp({
+      'shared/x.tsx': ROUTE_SOURCE,
+      'app/__/shared/x.tsx': ROUTE_SOURCE,
+    });
+    const routes: Record<string, Route> = {
+      root: { id: 'root', file: 'root.tsx', path: '' },
+      outside: {
+        id: 'outside',
+        parentId: 'root',
+        file: '../shared/x.tsx',
+        path: 'outside',
+      },
+      inside: {
+        id: 'inside',
+        parentId: 'root',
+        file: '__/shared/x.tsx',
+        path: 'inside',
+      },
+    };
+
+    try {
+      expect(() =>
+        createClassicWebRouteEntries({
+          appDirectory: appDir,
+          isBuild: true,
+          routes,
+          splitRouteModules: true,
+        })
+      ).toThrowError(/both resolve to the entry name "__\/shared\/x"/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('shares one entry between routes that point at the same file', () => {
     // React Router requires explicit ids when two routes reuse a file. Both
     // routes import the very same module, and a route chunk is a pure function

--- a/tests/react-router-config.test.ts
+++ b/tests/react-router-config.test.ts
@@ -45,6 +45,10 @@ describe('resolveReactRouterConfig', () => {
       rsbuildConfig,
     });
     expect(buildEndCalls).toEqual(['preset', 'user']);
+    // buildEnd receives the resolved future flags, including defaults.
+    expect(result.resolved.future.unstable_enableNodeReadableStream).toBe(
+      false
+    );
   });
 
   it('runs every buildEnd hook before propagating a failure', async () => {

--- a/tests/react-router-framework/integration/presets-test.ts
+++ b/tests/react-router-framework/integration/presets-test.ts
@@ -246,9 +246,17 @@ test.describe("presets", async () => {
         "unstable_routeConfig",
       ]);
 
-      // Ensure future flags from presets are properly merged
+      // Ensure future flags from presets are properly merged. Like upstream,
+      // `buildEnd` receives the resolved flags with defaults filled in; the
+      // plugin resolves the flags of both supported React Router majors.
       expect(buildEndArgsMeta.futureFlags).toEqual({
+        unstable_enableNodeReadableStream: false,
         unstable_optimizeDeps: true,
+        unstable_subResourceIntegrity: false,
+        unstable_trailingSlashAwareDataRequests: true,
+        v8_middleware: false,
+        v8_splitRouteModules: false,
+        v8_viteEnvironmentApi: false,
       });
       expect(buildEndArgsMeta.splitRouteModules).toBe(true);
 


### PR DESCRIPTION
## Summary

Two follow-ups from the automated review comments on #116 and #119.

- `createClassicWebRouteEntries` now throws a clear error when two distinct route files sanitize to the same entry name (for example `../shared/x.tsx` and `app/__/shared/x.tsx`). Previously one entry overwrote the other and both routes served whichever module was retained. Routes that intentionally share a file still share one entry.
- `buildEnd` receives the fully resolved config. It previously replaced the resolved `future` with the raw user or preset object, so React Router 8.3 hooks saw `undefined` for `unstable_enableNodeReadableStream` instead of the default `false`.

Patch changeset included.

## Verification

`pnpm typecheck` and the affected unit files (`react-router-config`, `index`, `classic-web-route-entries`, `dts-build`) pass; new test covers the collision error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
