### PR TITLE
test: port upstream React Router corpus changes through 7aea711d

### DIFF
--- a/tests/react-router-framework/UPSTREAM.json
+++ b/tests/react-router-framework/UPSTREAM.json
@@ -1,7 +1,7 @@
 {
   "repository": "https://github.com/remix-run/react-router",
-  "lastReviewedRef": "2edaca7a4f12a50cad002d55d84f73b0cdd462b6",
-  "reviewedAt": "2026-08-27T00:00:00.000Z",
+  "lastReviewedRef": "7aea711dd1ae2bc5a076d13ff17291829690fa74",
+  "reviewedAt": "2026-09-04T00:00:00.000Z",
   "sourceDirs": [
     "integration",
     "packages/react-router-dev/__tests__"

--- a/tests/react-router-framework/integration/cli-test.ts
+++ b/tests/react-router-framework/integration/cli-test.ts
@@ -1,12 +1,12 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import * as path from "node:path";
 
 import { expect, test } from "@playwright/test";
 import dedent from "dedent";
 import semver from "semver";
 
-import { createProject } from "./helpers/rsbuild";
+import { build, createProject } from "./helpers/rsbuild";
 
 const nodeBin = process.argv[0];
 const reactRouterBin = "node_modules/@react-router/dev/dist/cli/index.js";
@@ -175,10 +175,46 @@ test.describe("cli", () => {
       expect(existsSync(entryServerFile)).toBeFalsy();
       expect(existsSync(entryClientFile)).toBeFalsy();
 
-      run(["reveal", "--no-typescript"], { cwd });
+      let { stderr, status } = run(["reveal", "--no-typescript"], {
+        cwd,
+        env: {
+          ...process.env,
+          FORCE_COLOR: undefined,
+          NO_COLOR: "1",
+        },
+      });
 
       expect(existsSync(entryServerFile)).toBeTruthy();
       expect(existsSync(entryClientFile)).toBeTruthy();
+      expect(readFileSync(entryServerFile, "utf-8")).toContain(
+        "renderToPipeableStream",
+      );
+      expect(readFileSync(entryServerFile, "utf-8")).not.toContain(
+        "import type",
+      );
+      expect(stderr.toString().trim()).toBe(
+        "The --no-typescript flag is deprecated and will be removed in React Router v9.",
+      );
+      expect(status).toBe(0);
+      expect(build({ cwd }).status).toBe(0);
+    });
+
+    test("generates a web JavaScript server entry for non-Node projects", async () => {
+      const cwd = await createProject();
+      let packageJsonPath = path.join(cwd, "package.json");
+      let pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+      delete pkg.dependencies["@react-router/express"];
+      delete pkg.dependencies["@react-router/node"];
+      delete pkg.dependencies["@react-router/serve"];
+      writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2));
+
+      let entryServerFile = path.join(cwd, "app", "entry.server.jsx");
+
+      run(["reveal", "entry.server", "--no-typescript"], { cwd });
+
+      expect(readFileSync(entryServerFile, "utf-8")).toContain(
+        "renderToReadableStream",
+      );
     });
   });
 });

--- a/tests/react-router-framework/integration/helpers/rsc-framework/start.js
+++ b/tests/react-router-framework/integration/helpers/rsc-framework/start.js
@@ -24,7 +24,13 @@ const resolveClientBuildPath = (requestPath, ...segments) => {
   return candidatePath;
 };
 
-app.use(base, express.static(clientBuildDirectory, { index: false }));
+// `redirect: false` keeps express.static from answering a prerendered route
+// directory such as `/other` with a 301 to `/other/`; the middleware below
+// serves `<path>/index.html` directly, like a static host or Vite preview.
+app.use(
+  base,
+  express.static(clientBuildDirectory, { index: false, redirect: false }),
+);
 
 // Serve prerendered documents, mirroring the Rsbuild RSC integration's
 // preview server middleware (`<path>/index.html` written at build time).

--- a/tests/react-router-framework/integration/react-router-serve-test.ts
+++ b/tests/react-router-framework/integration/react-router-serve-test.ts
@@ -81,4 +81,46 @@ test.describe("react-router-serve", () => {
       });
     });
   }
+
+  test.describe("well-known URIs", () => {
+    for (const templateName of templateNames) {
+      test.describe(`template: ${templateName}`, () => {
+        let fixture: Fixture;
+        let appFixture: AppFixture;
+
+        test.beforeAll(async () => {
+          fixture = await createFixture({
+            templateName,
+            useReactRouterServe: true,
+            files: {
+              "public/.well-known/security.txt":
+                "Contact: mailto:security@example.com",
+              "public/.hidden.txt": "should not be served",
+            },
+          });
+          appFixture = await createAppFixture(fixture);
+        });
+
+        test.afterAll(() => {
+          appFixture.close();
+        });
+
+        test("serves files under /.well-known", async () => {
+          let response = await fetch(
+            `${appFixture.serverUrl}/.well-known/security.txt`,
+          );
+          expect(response.status).toBe(200);
+          expect(await response.text()).toContain(
+            "Contact: mailto:security@example.com",
+          );
+        });
+
+        test("keeps other dotfiles hidden", async () => {
+          let response = await fetch(`${appFixture.serverUrl}/.hidden.txt`);
+          expect(response.status).toBe(404);
+          expect(await response.text()).not.toContain("should not be served");
+        });
+      });
+    }
+  });
 });

--- a/tests/react-router-framework/integration/rsc-client-version-test.ts
+++ b/tests/react-router-framework/integration/rsc-client-version-test.ts
@@ -1,0 +1,269 @@
+import { expect, type Page } from "@playwright/test";
+
+import {
+  reactRouterConfig,
+  test,
+  type Files,
+  type TemplateName,
+} from "./helpers/rsbuild.js";
+
+// Adapted from upstream `rsc-client-version-test.ts`. Upstream cross-checks the
+// client version against Vite's `__vite_rsc_assets_manifest.js`; this plugin
+// derives it from its own build, so the version is read from the manifest
+// request the browser issues instead.
+
+const js = String.raw;
+const templateName = "rsc-framework" as const satisfies TemplateName;
+
+function getFiles() {
+  return {
+    "app/root.tsx": js`
+      import { Link, Outlet } from "react-router";
+
+      export default function Root() {
+        return (
+          <html lang="en">
+            <body>
+              <Link to="/other?token=abc123&ref=campaign#section1">
+                Go to Other
+              </Link>
+              <Outlet />
+            </body>
+          </html>
+        );
+      }
+    `,
+    "app/routes/_index.tsx": js`
+      export default function Index() {
+        return <h1>Home</h1>;
+      }
+    `,
+    "app/routes/other.tsx": js`
+      import { useLocation } from "react-router";
+
+      export default function Other() {
+        let location = useLocation();
+        return (
+          <h1 data-location>
+            {location.pathname + location.search + location.hash}
+          </h1>
+        );
+      }
+    `,
+  };
+}
+
+function trackDocumentRequests(page: Page) {
+  let requests: string[] = [];
+  page.on("request", (request) => {
+    if (request.resourceType() === "document") {
+      requests.push(request.url());
+    }
+  });
+  return requests;
+}
+
+function trackManifestRequests(page: Page) {
+  let requests: string[] = [];
+  page.on("request", (request) => {
+    if (/\.manifest(?:\?|$)/.test(request.url())) {
+      requests.push(request.url());
+    }
+  });
+  return requests;
+}
+
+async function interceptWithStaleClientVersion(page: Page) {
+  let manifestRequests: string[] = [];
+  await page.route(/\.manifest(?:\?|$)/, async (route) => {
+    let url = new URL(route.request().url());
+    manifestRequests.push(url.href);
+    url.searchParams.set("version", "stale");
+    await route.continue({ url: url.href });
+  });
+  return manifestRequests;
+}
+
+test.describe("RSC client versions", () => {
+  test("sends a stable client version with route discovery", async ({
+    page,
+    request,
+    rsbuildPreview,
+  }) => {
+    let files: Files = async () => getFiles();
+    let { port } = await rsbuildPreview(files, templateName);
+    let baseUrl = `http://localhost:${port}`;
+    let documentRequests = trackDocumentRequests(page);
+    let manifestRequests = trackManifestRequests(page);
+
+    await page.goto(`${baseUrl}/`);
+    await expect.poll(() => manifestRequests.length).toBeGreaterThan(0);
+    // Upstream's Vite build uses an 8-character version; this plugin emits a
+    // longer content hash. Only the shape matters here.
+    expect(manifestRequests[0]).toMatch(
+      /\/other\.manifest\?version=[a-f0-9]{8,}$/,
+    );
+
+    let clientVersion = new URL(manifestRequests[0]).searchParams.get(
+      "version",
+    );
+    let currentResponse = await request.get(
+      `${baseUrl}/other.manifest?version=${clientVersion}`,
+    );
+    expect(currentResponse.status()).toBe(200);
+
+    await page.getByRole("link", { name: "Go to Other" }).click();
+    await expect(page.locator("[data-location]")).toHaveText(
+      "/other?token=abc123&ref=campaign#section1",
+    );
+    expect(documentRequests).toHaveLength(1);
+  });
+
+  test("defers an eager discovery mismatch until navigation, then reloads the destination", async ({
+    page,
+    rsbuildPreview,
+  }) => {
+    let files: Files = async () => getFiles();
+    let { port } = await rsbuildPreview(files, templateName);
+    let baseUrl = `http://localhost:${port}`;
+    let documentRequests = trackDocumentRequests(page);
+    let manifestRequests = await interceptWithStaleClientVersion(page);
+    let eagerMismatch = page.waitForResponse(
+      (response) =>
+        response.url().includes(".manifest") && response.status() === 204,
+    );
+
+    await page.goto(`${baseUrl}/`);
+    await eagerMismatch;
+    await expect.poll(() => manifestRequests.length).toBeGreaterThan(0);
+
+    // An eager discovery mismatch should not disrupt the current document.
+    await expect(page.getByRole("heading", { name: "Home" })).toBeVisible();
+    expect(documentRequests).toHaveLength(1);
+
+    await page.getByRole("link", { name: "Go to Other" }).click();
+
+    await expect(page.locator("[data-location]")).toHaveText(
+      "/other?token=abc123&ref=campaign#section1",
+    );
+    expect(page.url()).toBe(
+      `${baseUrl}/other?token=abc123&ref=campaign#section1`,
+    );
+    expect(documentRequests).toHaveLength(2);
+    expect(documentRequests[1]).toBe(
+      `${baseUrl}/other?token=abc123&ref=campaign`,
+    );
+  });
+
+  test("reloads when a prerendered RSC payload has a new client version", async ({
+    page,
+    request,
+    rsbuildPreview,
+  }) => {
+    let files: Files = async () => ({
+      ...getFiles(),
+      "react-router.config.ts": reactRouterConfig({
+        ssr: false,
+        prerender: ["/", "/other"],
+      }),
+      "app/root.tsx": js`
+        import { Link, Outlet } from "react-router";
+
+        export default function Root() {
+          return (
+            <html lang="en">
+              <body>
+                <Link to="/other">Go to Other</Link>
+                <Outlet />
+              </body>
+            </html>
+          );
+        }
+      `,
+    });
+    let { port } = await rsbuildPreview(files, templateName);
+    let baseUrl = `http://localhost:${port}`;
+    let documentRequests = trackDocumentRequests(page);
+
+    // With `ssr: false` every route is in the initial manifest, so no discovery
+    // request reveals the client version. Read it from the prerendered payload
+    // itself, then rewrite the first payload the browser fetches for /other so
+    // it advertises a different version.
+    let prerenderedPayload = await (
+      await request.get(`${baseUrl}/other.rsc`)
+    ).text();
+    let clientVersion = /"clientVersion":"([a-f0-9]+)"/.exec(
+      prerenderedPayload,
+    )?.[1];
+    expect(clientVersion).toMatch(/^[a-f0-9]{8,}$/);
+    let newVersion = clientVersion === "deadbeef" ? "feedface" : "deadbeef";
+
+    let replacedVersion = false;
+    await page.route(/\/other\.rsc(?:\?|$)/, async (route) => {
+      if (replacedVersion) {
+        await route.continue();
+        return;
+      }
+
+      replacedVersion = true;
+      let response = await route.fetch();
+      let source = await response.text();
+      expect(source).toContain(clientVersion!);
+      await route.fulfill({
+        response,
+        body: source.replaceAll(clientVersion!, newVersion),
+      });
+    });
+
+    await page.goto(`${baseUrl}/`);
+    let rscResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes("/other.rsc") && response.status() === 200,
+    );
+
+    await page.getByRole("link", { name: "Go to Other" }).click();
+    await rscResponse;
+
+    await expect(page.locator("[data-location]")).toHaveText("/other");
+    expect(documentRequests).toHaveLength(2);
+    expect(documentRequests[1]).toBe(`${baseUrl}/other`);
+  });
+
+  test("does not reload repeatedly for the same stale client version", async ({
+    page,
+    rsbuildPreview,
+  }) => {
+    let files: Files = async () => getFiles();
+    let { port } = await rsbuildPreview(files, templateName);
+    let baseUrl = `http://localhost:${port}`;
+    let documentRequests = trackDocumentRequests(page);
+    let manifestRequests = await interceptWithStaleClientVersion(page);
+    let consoleErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") consoleErrors.push(message.text());
+    });
+    let eagerMismatch = page.waitForResponse(
+      (response) =>
+        response.url().includes(".manifest") && response.status() === 204,
+    );
+
+    await page.goto(`${baseUrl}/`);
+    await eagerMismatch;
+    await expect.poll(() => manifestRequests.length).toBeGreaterThan(0);
+
+    let clientVersion = new URL(manifestRequests[0]).searchParams.get(
+      "version",
+    );
+    await page.evaluate((version) => {
+      sessionStorage.setItem("react-router-manifest-version", version!);
+    }, clientVersion);
+
+    await page.getByRole("link", { name: "Go to Other" }).click();
+    await expect.poll(() => manifestRequests.length).toBeGreaterThan(1);
+    await expect
+      .poll(() => consoleErrors)
+      .toContain("Unable to discover routes due to manifest version mismatch.");
+
+    expect(documentRequests).toHaveLength(1);
+  });
+});

--- a/tests/react-router-framework/integration/rsc-csrf-action-test.ts
+++ b/tests/react-router-framework/integration/rsc-csrf-action-test.ts
@@ -1,0 +1,169 @@
+import { test, expect, type Page } from "@playwright/test";
+import getPort from "get-port";
+
+import { PlaywrightFixture } from "./helpers/playwright-fixture.js";
+import {
+  createAppFixture,
+  createFixture,
+  js,
+} from "./helpers/create-fixture.js";
+import type { AppFixture, Fixture } from "./helpers/create-fixture.js";
+import { implementations, setupRscTest, validateRSCHtml } from "./rsc/utils.js";
+
+const csrfActionRoute = js`
+  let actionCalls = 0;
+
+  export function loader() {
+    return { actionCalls };
+  }
+
+  export async function action() {
+    actionCalls++;
+    return null;
+  }
+
+  export default function Component({ loaderData }) {
+    return (
+      <p data-action-calls={loaderData.actionCalls}>
+        Action calls: {loaderData.actionCalls}
+      </p>
+    );
+  }
+`;
+
+async function expectActionCalls(page: Page, count: string) {
+  await page.waitForSelector("[data-action-calls]");
+  expect(await page.locator("[data-action-calls]").textContent()).toContain(
+    `Action calls: ${count}`,
+  );
+  expect(
+    await page.locator("[data-action-calls]").getAttribute("data-action-calls"),
+  ).toBe(count);
+}
+
+test.describe("RSC CSRF action protection", () => {
+  test.describe("RSC Framework", () => {
+    let fixture: Fixture;
+    let appFixture: AppFixture | undefined;
+
+    test.beforeAll(async () => {
+      fixture = await createFixture({
+        templateName: "rsc-framework",
+        files: {
+          "app/routes/csrf-action.tsx": csrfActionRoute,
+        },
+      });
+
+      appFixture = await createAppFixture(fixture);
+    });
+
+    test.afterAll(() => {
+      appFixture?.close();
+    });
+
+    test("does not call actions on cross-origin document POST requests", async ({
+      page,
+      request,
+    }) => {
+      let app = new PlaywrightFixture(appFixture!, page);
+
+      await app.goto("/csrf-action");
+      await expectActionCalls(page, "0");
+      validateRSCHtml(await page.content());
+
+      let response = await request.post(
+        `${appFixture!.serverUrl}/csrf-action`,
+        {
+          form: { intent: "mutate" },
+          headers: {
+            Origin: "https://attacker.example",
+          },
+        },
+      );
+      expect(response.status()).toBe(400);
+
+      await app.goto("/csrf-action");
+      await expectActionCalls(page, "0");
+    });
+  });
+
+  implementations.forEach((implementation) => {
+    test.describe(`RSC Data (${implementation.name})`, () => {
+      let port: number;
+      let stopAfterAll: () => void;
+
+      test.beforeAll(async () => {
+        port = await getPort();
+        stopAfterAll = await setupRscTest({
+          implementation,
+          port,
+          files: {
+            "src/routes.ts": js`
+              import type { unstable_RSCRouteConfig as RSCRouteConfig } from "react-router";
+
+              export const routes = [
+                {
+                  id: "root",
+                  path: "",
+                  lazy: () => import("./routes/root"),
+                  children: [
+                    {
+                      id: "csrf-action",
+                      path: "csrf-action",
+                      lazy: () => import("./routes/csrf-action"),
+                    },
+                  ],
+                },
+              ] satisfies RSCRouteConfig;
+            `,
+
+            "src/routes/root.tsx": js`
+              import { Outlet } from "react-router";
+
+              export function Layout({ children }: { children: React.ReactNode }) {
+                return (
+                  <html>
+                    <body>{children}</body>
+                  </html>
+                );
+              }
+
+              export default function RootRoute() {
+                return <Outlet />;
+              }
+            `,
+
+            "src/routes/csrf-action.tsx": csrfActionRoute,
+          },
+        });
+      });
+
+      test.afterAll(() => {
+        stopAfterAll?.();
+      });
+
+      test("does not call actions on cross-origin document POST requests", async ({
+        page,
+        request,
+      }) => {
+        await page.goto(`http://localhost:${port}/csrf-action`);
+        await expectActionCalls(page, "0");
+        validateRSCHtml(await page.content());
+
+        let response = await request.post(
+          `http://localhost:${port}/csrf-action`,
+          {
+            form: { intent: "mutate" },
+            headers: {
+              Origin: "https://attacker.example",
+            },
+          },
+        );
+        expect(response.status()).toBe(400);
+
+        await page.goto(`http://localhost:${port}/csrf-action`);
+        await expectActionCalls(page, "0");
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Audit of the ported React Router integration corpus against upstream `remix-run/react-router@7aea711d` (41 commits past the recorded `2edaca7a` checkpoint), using `pnpm check:react-router-framework-upstream`. All ported and adapted suites pass locally, and the full corpus passed on `main` in the last Build Test.

Ported:
- **cli-test**: `reveal --no-typescript` deprecation notice, generated Node server entry content, build still succeeds; new web-streams entry case for non-Node projects (both in React Router 8.3.1).
- **react-router-serve-test**: `/.well-known` files served, other dotfiles hidden (8.3.1).
- **rsc-csrf-action-test** (new file): cross-origin document POSTs do not run actions, RSC framework and RSC data modes. Ported unchanged apart from the template name; passes against this plugin.
- **rsc-client-version-test** (new file): React Router 8.3 stale-client detection in RSC production builds. Adapted to read the client version from the discovery request or the prerendered payload instead of Vite's `__vite_rsc_assets_manifest.js`, and to accept this plugin's longer hash.

Harness: the RSC fixture server sets `redirect: false` on `express.static` so a prerendered route directory like `/other` is served by the existing `<path>/index.html` middleware instead of a 301 to `/other/`, matching static hosts and upstream's preview.

Not ported, on purpose:
- **rsc-nonce-test**: the plugin's RSC entries have no CSP nonce plumbing, so this is a feature gap rather than a test gap. Tracked separately.
- **plugin-cloudflare-test**, **plugin-order-validation-test**: Vite plugin specific.

`UPSTREAM.json` now records `7aea711d` as the reviewed ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
