### PR TITLE
fix: hash the manifest version with sha256 for FIPS hosts

### DIFF
--- a/.changeset/fips-safe-manifest-hash.md
+++ b/.changeset/fips-safe-manifest-hash.md
@@ -1,0 +1,8 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Hash the browser manifest version with sha256 instead of md5, which is
+unavailable on FIPS-enabled machines and made builds fail there. The version
+is a short content digest, so existing deployments only see the manifest file
+name change once.

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -609,7 +609,8 @@ function generateReactRouterManifestForDevEffect(
     // compares the browser's manifest version with the pinned server build's,
     // and a random per-compilation version made unchanged manifests differ
     // whenever a web compilation completed without a new server pin.
-    const version = createHash('md5')
+    // sha256 rather than md5: md5 is unavailable on FIPS-enabled hosts (#124).
+    const version = createHash('sha256')
       .update(JSON.stringify(fingerprintedValues))
       .digest('hex')
       .slice(0, 8);


### PR DESCRIPTION
## Summary

The browser manifest version was an md5 digest, and md5 is unavailable when Node runs on a FIPS-enabled machine, so builds threw there (#124). Use sha256, which is FIPS-approved; the version only needs to be a short, stable content digest. The other two hashes in the plugin were already sha256 and sha384.

Existing deployments see the manifest file name change once. Patch changeset included.

Fixes #124

## Verification

`pnpm typecheck`, `pnpm build`, and the manifest unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)