### PR TITLE
docs: describe output.autoExternal for Node server builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,30 @@ and every configured bundle are
 evaluated and published as one generation; one failing bundle keeps the whole
 previous generation active.
 
+### Externalizing server dependencies
+
+The server bundle includes your dependencies by default, which suits targets
+that ship a single file such as Cloudflare Workers. For Node hosts you can let
+Rsbuild leave `package.json` dependencies external so the server build stays
+small and native or generated packages (Prisma, database drivers) load from
+`node_modules` at runtime, matching React Router's Vite default:
+
+```ts
+// rsbuild.config.ts
+export default defineConfig({
+  environments: {
+    node: {
+      output: { autoExternal: true },
+    },
+  },
+  plugins: [pluginReactRouter(), pluginReact()],
+});
+```
+
+`output.autoExternal` (Rsbuild 2.0.7+) externalizes `dependencies`,
+`peerDependencies`, and `optionalDependencies`, including subpath imports such
+as `react/jsx-runtime`. The plugin's own server output works unchanged with it.
+
 ### Sharing `createContext()` instances with a custom server
 
 React Router middleware contexts are matched by identity, so a custom server's


### PR DESCRIPTION
## Summary

Documents Rsbuild's built-in `output.autoExternal` (2.0.7+) as the way to keep dependencies out of the server bundle on Node hosts. Verified on the default template: server output 463 KB → 10 KB, `react-router`, `react-dom/server`, `@react-router/node`, `isbot` and friends left external, `react-router-serve` serves the app unchanged. This matches React Router's Vite SSR default and avoids bundling generated packages like Prisma. Kept opt-in because the Cloudflare example and other single-file targets rely on bundling.

Docs only; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)