### PR TITLE
fix: respect user web output filename, publicPath, and tools.rspack (#129, #130)

### DIFF
--- a/.changeset/respect-user-web-output.md
+++ b/.changeset/respect-user-web-output.md
@@ -32,5 +32,18 @@ Respect user web output settings instead of overriding them (#129, #130).
   container URL; the federation example does this now.
 - RSC framework mode reads the browser bootstrap scripts from the rspack RSC
   manifest (`entryJsFiles`, in order) instead of assuming `index.js`. When the
-  prefix rspack applied differs from the server prefix (browser compiler on
-  `'auto'`), it is swapped rather than stacked.
+  browser compiler is on `'auto'`, rspack records `/` as the manifest prefix;
+  the plugin aligns the manifest once, in place, with the server prefix, so
+  bootstrap scripts, route stylesheets, client-reference stylesheets, and
+  Flight's preload prefix agree. An empty `entryJsFiles` is an explicit error,
+  and RSC mode rejects web `output.filename.js` values that do not end in
+  `.js` (rspack's collector drops them) at config time.
+- Browser-manifest assets are classified by pathname (`.js`/`.mjs`/`.cjs`, with
+  or without a query); a chunk whose metadata names no script fails the build
+  instead of guessing a filename.
+- `onBeforeCreateCompiler` no longer asks Rsbuild for the `web` environment's
+  normalized config, which throws when the build is narrowed to other
+  environments (`--environment node`).
+- Federation example: the remote now serves its assets with CORS, names both
+  containers explicitly, publishes its server async chunks where the Node
+  federation runtime resolves them, and puts the browser compiler on `'auto'`.

--- a/.changeset/respect-user-web-output.md
+++ b/.changeset/respect-user-web-output.md
@@ -4,23 +4,33 @@
 
 Respect user web output settings instead of overriding them (#129, #130).
 
-- The plugin no longer forces web `output.filename.js` to `[name].js`. Production
-  browser entries now get Rsbuild's default content hash
-  (`[name].[contenthash:10].js`), and a user `output.filename.js` (string or
-  function) is honored. When the user configures `filename.js`, the plugin's
-  classic-mode async `chunkFilename` default also steps aside so Rsbuild can
-  derive the async chunk name from the user's scheme.
+- The plugin no longer forces web `output.filename.js` to `[name].js`, and no
+  longer sets the classic-mode async `chunkFilename`. Rsbuild owns every browser
+  JavaScript filename: production entries get Rsbuild's default content hash,
+  and `output.filename.js` (string or function), `output.filenameHash`,
+  `output.distPath.jsAsync`, and query-hash filenames such as
+  `[name].js?v=[contenthash:8]` are honored. The browser manifest classifies
+  emitted assets by pathname and keeps the full emitted reference, so any
+  naming scheme resolves to the right route module.
 - The plugin no longer copies the root `assetPrefix` onto the web compiler's
-  `output.publicPath`. Rsbuild derives `publicPath` from the environment's
+  `output.publicPath`. Rsbuild derives `publicPath` from the web environment's
   `output.assetPrefix`, so `environments.web.output.assetPrefix: 'auto'` (or a
-  per-environment CDN prefix) now reaches the browser runtime, and async CSS
-  resolves from the script origin as expected. The server build and browser
-  manifest keep an absolute prefix, resolved from the web environment
-  (falling back to the root), with `'auto'` normalized to `/`.
+  per-environment CDN prefix) reaches the browser runtime and async CSS resolves
+  relative to the loaded script. The server build and browser manifest still
+  need an absolute prefix: they use the web environment's prefix when it is
+  usable and otherwise fall back to the root prefix, so
+  `output.assetPrefix: 'https://cdn.example.com/'` + web `'auto'` keeps emitting
+  CDN URLs from the server (`'auto'` is only folded to `/` when nothing else is
+  configured).
 - Rspack `output` defaults for the web and node environments are applied via
   `modifyRspackConfig`, which Rsbuild runs before the user's `tools.rspack`, so
-  both the object and function forms of `tools.rspack` can override plugin
-  output defaults such as `chunkFilename`.
-- RSC framework mode reads the browser bootstrap script from the rspack RSC
-  manifest (`entryJsFiles`) at runtime instead of assuming `index.js`, so hashed
-  entry filenames work there too.
+  both the object and function forms of `tools.rspack` override plugin output
+  defaults such as the server `chunkFilename`.
+- Module Federation remotes: the browser container chunk is no longer implicitly
+  emitted as `<name>.js`. Set `filename` on `ModuleFederationPlugin` (for
+  example `filename: 'static/js/remote.js'`) so the host keeps a stable
+  container URL; the federation example does this now.
+- RSC framework mode reads the browser bootstrap scripts from the rspack RSC
+  manifest (`entryJsFiles`, in order) instead of assuming `index.js`. When the
+  prefix rspack applied differs from the server prefix (browser compiler on
+  `'auto'`), it is swapped rather than stacked.

--- a/.changeset/respect-user-web-output.md
+++ b/.changeset/respect-user-web-output.md
@@ -1,0 +1,26 @@
+---
+'rsbuild-plugin-react-router': patch
+---
+
+Respect user web output settings instead of overriding them (#129, #130).
+
+- The plugin no longer forces web `output.filename.js` to `[name].js`. Production
+  browser entries now get Rsbuild's default content hash
+  (`[name].[contenthash:10].js`), and a user `output.filename.js` (string or
+  function) is honored. When the user configures `filename.js`, the plugin's
+  classic-mode async `chunkFilename` default also steps aside so Rsbuild can
+  derive the async chunk name from the user's scheme.
+- The plugin no longer copies the root `assetPrefix` onto the web compiler's
+  `output.publicPath`. Rsbuild derives `publicPath` from the environment's
+  `output.assetPrefix`, so `environments.web.output.assetPrefix: 'auto'` (or a
+  per-environment CDN prefix) now reaches the browser runtime, and async CSS
+  resolves from the script origin as expected. The server build and browser
+  manifest keep an absolute prefix, resolved from the web environment
+  (falling back to the root), with `'auto'` normalized to `/`.
+- Rspack `output` defaults for the web and node environments are applied via
+  `modifyRspackConfig`, which Rsbuild runs before the user's `tools.rspack`, so
+  both the object and function forms of `tools.rspack` can override plugin
+  output defaults such as `chunkFilename`.
+- RSC framework mode reads the browser bootstrap script from the rspack RSC
+  manifest (`entryJsFiles`) at runtime instead of assuming `index.js`, so hashed
+  entry filenames work there too.

--- a/.changeset/respect-user-web-output.md
+++ b/.changeset/respect-user-web-output.md
@@ -1,5 +1,5 @@
 ---
-'rsbuild-plugin-react-router': patch
+'rsbuild-plugin-react-router': minor
 ---
 
 Respect user web output settings instead of overriding them (#129, #130).

--- a/README.md
+++ b/README.md
@@ -341,16 +341,29 @@ Route components support the following exports:
 
 If you configure `output.assetPrefix` in Rsbuild, the plugin uses that value
 for the React Router browser manifest and server build `publicPath` so asset
-URLs resolve correctly when serving from a CDN or sub-path. The web
-environment's own `output.assetPrefix` (for example
-`environments.web.output.assetPrefix: 'auto'`) takes precedence for the browser
-bundle and is passed through to Rspack untouched; the manifest and server build
-always use an absolute prefix, so `'auto'` is treated as `/` there.
+URLs resolve correctly when serving from a CDN or sub-path.
 
-The plugin does not override `output.filename.js` or `output.publicPath` for
-the web environment. Production browser entries use Rsbuild's default
-content-hashed filenames, and any `output.filename` or `tools.rspack` output
-settings you configure take precedence over the plugin's defaults.
+The web environment's own `output.assetPrefix` is passed through to the browser
+compiler untouched, so `environments.web.output.assetPrefix: 'auto'` lets the
+browser runtime resolve async chunks and stylesheets relative to the loaded
+script. The server build and browser manifest need an absolute prefix: they use
+the web environment's prefix when it is usable and otherwise fall back to the
+root `output.assetPrefix`. A common CDN setup is therefore:
+
+```ts
+export default defineConfig({
+  output: { assetPrefix: 'https://cdn.example.com/app/' }, // server-rendered URLs
+  environments: {
+    web: { output: { assetPrefix: 'auto' } }, // browser runtime resolves itself
+  },
+});
+```
+
+The plugin does not set `output.filename`, `chunkFilename`, or `publicPath`
+for the web environment. Production browser entries use Rsbuild's default
+content-hashed filenames, and `output.filename`, `output.filenameHash`,
+`output.distPath`, and `tools.rspack` output settings you configure govern
+the emitted files and the manifest URLs that reference them.
 
 ## Custom Server Setup
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,16 @@ Route components support the following exports:
 
 If you configure `output.assetPrefix` in Rsbuild, the plugin uses that value
 for the React Router browser manifest and server build `publicPath` so asset
-URLs resolve correctly when serving from a CDN or sub-path.
+URLs resolve correctly when serving from a CDN or sub-path. The web
+environment's own `output.assetPrefix` (for example
+`environments.web.output.assetPrefix: 'auto'`) takes precedence for the browser
+bundle and is passed through to Rspack untouched; the manifest and server build
+always use an absolute prefix, so `'auto'` is treated as `/` there.
+
+The plugin does not override `output.filename.js` or `output.publicPath` for
+the web environment. Production browser entries use Rsbuild's default
+content-hashed filenames, and any `output.filename` or `tools.rspack` output
+settings you configure take precedence over the plugin's defaults.
 
 ## Custom Server Setup
 

--- a/examples/federation/epic-stack-remote/rsbuild.config.ts
+++ b/examples/federation/epic-stack-remote/rsbuild.config.ts
@@ -76,6 +76,9 @@ const webFederationConfig = {
 		asyncStartup: true,
 	},
 	dts: false,
+	// The host loads the container from this fixed URL, so name it explicitly.
+	// Every other browser chunk keeps Rsbuild's content hash.
+	filename: 'static/js/remote.js',
 	library: {
 		type: 'module'
 	},

--- a/examples/federation/epic-stack-remote/rsbuild.config.ts
+++ b/examples/federation/epic-stack-remote/rsbuild.config.ts
@@ -91,6 +91,10 @@ const nodeFederationConfig = {
 		asyncStartup: true,
 	},
 	dts: false,
+	// The server build is published under the client build's `static/` (see the
+	// plugin's federation copy), so the host loads this container from
+	// `<origin>/static/static/js/remote.js`.
+	filename: 'static/js/remote.js',
 	library: {
 		type: 'commonjs-module'
 	},
@@ -124,6 +128,12 @@ export default defineConfig({
 				define: {
 					WEB: 'true'
 				}
+			},
+			output: {
+				// The browser runtime derives its asset base from the script it was
+				// loaded from, so the same build works wherever the host fetches the
+				// container from. Server-rendered URLs keep REMOTE_ASSET_PREFIX.
+				assetPrefix: 'auto',
 			},
 			tools: {
 				rspack: {

--- a/examples/federation/epic-stack-remote/server/index.ts
+++ b/examples/federation/epic-stack-remote/server/index.ts
@@ -81,6 +81,14 @@ export async function createApp(devServer?: any) {
 	// http://expressjs.com/en/advanced/best-practice-security.html#at-a-minimum-disable-x-powered-by-header
 	app.disable('x-powered-by')
 
+	// The host loads this remote's container and the ES modules it imports
+	// cross-origin (`remoteType: 'import'`), which requires CORS on every asset
+	// response. Set it before any static handler.
+	app.use((_req, res, next) => {
+		res.setHeader('Access-Control-Allow-Origin', '*')
+		next()
+	})
+
 	if (IS_DEV) {
 		// use rsbuild dev server
 		if (devServer) {
@@ -97,6 +105,15 @@ export async function createApp(devServer?: any) {
 		// more aggressive with this caching.
 		app.use(express.static('build/client', { maxAge: '1h' }))
 		app.use('/server', express.static('build/server', { maxAge: '1h' }))
+		// The host's Node federation runtime resolves this remote's server chunks
+		// against the node compiler's publicPath (`REMOTE_ASSET_PREFIX`), i.e.
+		// `<origin>/static/js/async/<chunk>.js`, not against the container URL.
+		// Publish the server async chunks there as well. Client async chunks are
+		// content-hashed, so the two trees do not collide.
+		app.use(
+			'/static/js/async',
+			express.static('build/server/static/js/async', { maxAge: '1h' }),
+		)
 	}
 
 	app.get(/^\/(img|favicons)\//, ((

--- a/examples/spa-mode/tests/e2e/spa-mode.test.ts
+++ b/examples/spa-mode/tests/e2e/spa-mode.test.ts
@@ -47,8 +47,8 @@ test.describe('SPA Mode', () => {
       const indexPath = join(CLIENT_DIR, 'index.html');
       const html = readFileSync(indexPath, 'utf-8');
 
-      // Should have entry.client.js for hydration
-      expect(html).toContain('entry.client.js');
+      // Should have the content-hashed entry.client bundle for hydration
+      expect(html).toMatch(/\/static\/js\/entry\.client\.[a-f0-9]{8,}\.js/);
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,22 +109,22 @@ importers:
         version: 2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0)
       '@rsbuild/plugin-less':
         specifier: 1.6.4
-        version: 1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
       '@rsbuild/plugin-mdx':
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 1.1.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(webpack@5.108.3(lightningcss@1.32.0))
       '@rsbuild/plugin-react':
         specifier: 2.1.0
         version: 2.1.0(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))
       '@rsbuild/plugin-sass':
         specifier: 1.5.3
-        version: 1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))
+        version: 1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))
       '@rsbuild/plugin-svgr':
         specifier: 2.0.4
-        version: 2.0.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(typescript@5.9.3)
+        version: 2.0.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(typescript@5.9.3)
       '@rsbuild/plugin-tailwindcss':
         specifier: 2.0.3
-        version: 2.0.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 2.0.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
       '@rslib/core':
         specifier: ^0.23.2
         version: 0.23.2(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0)(typescript@5.9.3)
@@ -262,7 +262,7 @@ importers:
     dependencies:
       '@react-router/express':
         specifier: ^7.18.3
-        version: 7.18.3(express@5.2.1)(react-router@7.18.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+        version: 7.18.3(express@4.22.2)(react-router@7.18.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       '@react-router/node':
         specifier: ^7.18.3
         version: 7.18.3(react-router@7.18.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
@@ -473,13 +473,13 @@ importers:
         version: 2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0)
       '@rsbuild/plugin-less':
         specifier: ^1.6.4
-        version: 1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
         version: 2.1.0(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.3
-        version: 1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))
+        version: 1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.3.2
@@ -2015,6 +2015,12 @@ importers:
       '@mdx-js/rollup':
         specifier: ^3.1.1
         version: 3.1.1(rollup@4.62.2)
+      '@module-federation/enhanced':
+        specifier: 2.5.1
+        version: 2.5.1(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.108.3(lightningcss@1.32.0))
+      '@module-federation/node':
+        specifier: 2.7.44
+        version: 2.7.44(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.108.3(lightningcss@1.32.0))
       '@react-router/dev':
         specifier: ^8.3.1
         version: 8.3.1(@react-router/serve@8.3.1(react-router@8.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3))(react-router@8.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@7.3.6(@types/node@22.20.0)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.51.2)(tsx@4.21.0))(wrangler@4.107.0(@cloudflare/workers-types@4.20260702.1)(@types/node@22.20.0))
@@ -2029,22 +2035,22 @@ importers:
         version: 2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0)
       '@rsbuild/plugin-less':
         specifier: 1.6.4
-        version: 1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
       '@rsbuild/plugin-mdx':
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 1.1.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(webpack@5.108.3(lightningcss@1.32.0))
       '@rsbuild/plugin-react':
         specifier: 2.1.0
         version: 2.1.0(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))
       '@rsbuild/plugin-sass':
         specifier: 1.5.3
-        version: 1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))
+        version: 1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))
       '@rsbuild/plugin-svgr':
         specifier: 2.0.4
-        version: 2.0.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(typescript@5.9.3)
+        version: 2.0.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(typescript@5.9.3)
       '@rsbuild/plugin-tailwindcss':
         specifier: 2.0.3
-        version: 2.0.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 2.0.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
       '@types/node':
         specifier: ^22.19.19
         version: 22.20.0
@@ -2123,22 +2129,22 @@ importers:
         version: 2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0)
       '@rsbuild/plugin-less':
         specifier: 1.6.4
-        version: 1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
       '@rsbuild/plugin-mdx':
         specifier: ^1.1.3
-        version: 1.1.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 1.1.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(webpack@5.108.3(lightningcss@1.32.0))
       '@rsbuild/plugin-react':
         specifier: 2.1.0
         version: 2.1.0(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))
       '@rsbuild/plugin-sass':
         specifier: 1.5.3
-        version: 1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))
+        version: 1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))
       '@rsbuild/plugin-svgr':
         specifier: 2.0.4
-        version: 2.0.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(typescript@5.9.3)
+        version: 2.0.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(typescript@5.9.3)
       '@rsbuild/plugin-tailwindcss':
         specifier: 2.0.3
-        version: 2.0.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
+        version: 2.0.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
@@ -12326,6 +12332,31 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
+  '@module-federation/enhanced@2.5.1(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.108.3(lightningcss@1.32.0))':
+    dependencies:
+      '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/cli': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)
+      '@module-federation/error-codes': 2.5.1
+      '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))
+      '@module-federation/managers': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/manifest': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)
+      '@module-federation/rspack': 2.5.1(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)
+      '@module-federation/runtime-tools': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/webpack-bundler-runtime': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
+      schema-utils: 4.3.0
+      tapable: 2.3.0
+      upath: 2.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+      webpack: 5.108.3(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - node-fetch
+      - utf-8-validate
+
   '@module-federation/error-codes@2.5.1': {}
 
   '@module-federation/inject-external-runtime-core-plugin@2.5.1(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))':
@@ -12362,6 +12393,23 @@ snapshots:
       tapable: 2.3.0
     optionalDependencies:
       webpack: 5.108.3(esbuild@0.27.2)(lightningcss@1.32.0)(postcss@8.5.28)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
+  '@module-federation/node@2.7.44(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.108.3(lightningcss@1.32.0))':
+    dependencies:
+      '@module-federation/enhanced': 2.5.1(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@5.9.3)(webpack@5.108.3(lightningcss@1.32.0))
+      '@module-federation/runtime': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
+      '@module-federation/sdk': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
+      encoding: 0.1.13
+      node-fetch: 2.7.0(encoding@0.1.13)
+      tapable: 2.3.0
+    optionalDependencies:
+      webpack: 5.108.3(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -13999,11 +14047,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0)
 
-  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))':
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))':
     dependencies:
       deepmerge: 4.3.1
       less: 4.6.7
-      less-loader: 12.3.3(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.108.3(lightningcss@1.32.0))
+      less-loader: 12.3.3(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.108.3(lightningcss@1.32.0))
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0)
@@ -14011,7 +14059,7 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-mdx@1.1.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(webpack@5.108.3(lightningcss@1.32.0))':
+  '@rsbuild/plugin-mdx@1.1.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(webpack@5.108.3(lightningcss@1.32.0))':
     dependencies:
       '@mdx-js/loader': 3.1.1(webpack@5.108.3(lightningcss@1.32.0))
     optionalDependencies:
@@ -14029,7 +14077,7 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/core'
 
-  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))':
+  '@rsbuild/plugin-sass@1.5.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))':
     dependencies:
       deepmerge: 4.3.1
       loader-utils: 2.0.4
@@ -14039,7 +14087,7 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0)
 
-  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(typescript@5.9.3)':
+  '@rsbuild/plugin-svgr@2.0.4(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(typescript@5.9.3)':
     dependencies:
       '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))
       '@svgr/core': 8.1.0(typescript@5.9.3)
@@ -14054,9 +14102,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1)(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))':
     dependencies:
-      '@tailwindcss/webpack': 4.3.2(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
+      '@tailwindcss/webpack': 4.3.2(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))
     optionalDependencies:
       '@rsbuild/core': 2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0)
     transitivePeerDependencies:
@@ -14758,7 +14806,7 @@ snapshots:
       postcss: 8.5.28
       tailwindcss: 4.3.2
 
-  '@tailwindcss/webpack@4.3.2(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))':
+  '@tailwindcss/webpack@4.3.2(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(webpack@5.108.3(lightningcss@1.32.0))':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.2
@@ -17914,7 +17962,7 @@ snapshots:
 
   leac@0.6.0: {}
 
-  less-loader@12.3.3(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1)(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.108.3(lightningcss@1.32.0)):
+  less-loader@12.3.3(@rspack/core@2.2.0(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(less@4.6.7)(webpack@5.108.3(lightningcss@1.32.0)):
     dependencies:
       less: 4.6.7
     optionalDependencies:

--- a/scripts/test-package-interop.mts
+++ b/scripts/test-package-interop.mts
@@ -46,6 +46,7 @@ const verifyRegistration = async (writer, reader) => {
     onBeforeBuild: noop,
     onBeforeCreateCompiler: noop,
     modifyBundlerChain: noop,
+    modifyRspackConfig: noop,
     isPluginExists: () => false,
     onBeforeStartDevServer: collect(starts),
     onAfterStartDevServer: noop,

--- a/src/environment-output.ts
+++ b/src/environment-output.ts
@@ -1,15 +1,64 @@
-import type { RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core';
 import { ensureFederationAsyncStartup } from './federation.js';
 
+/**
+ * Rspack `output` policy for the web and node environments, in two tiers:
+ *
+ * 1. Overridable defaults, registered through `modifyRspackConfig`. Rsbuild
+ *    runs the user's `tools.rspack` (object or function form) after this hook,
+ *    so user output settings such as `chunkFilename` take precedence
+ *    (#129, #130). Neither `filename` nor `publicPath` is set here: Rsbuild
+ *    derives them from `output.filename`/`output.filenameHash`/`output.distPath`
+ *    and the environment's `output.assetPrefix`, which keeps `'auto'` intact.
+ * 2. Enforced invariants, registered through a `tools.rspack` function that
+ *    runs after the user's own `tools.rspack`: the server library type must
+ *    match the server module format, and federation builds need async startup.
+ */
 export const registerReactRouterEnvironmentOutput = ({
   api,
   federation,
   resolvedServerOutput,
+  webOutput,
 }: {
   api: RsbuildPluginAPI;
   federation: boolean | undefined;
   resolvedServerOutput: 'commonjs' | 'module';
+  webOutput: NonNullable<Rspack.Configuration['output']>;
 }): void => {
+  const nodeChunkLoading =
+    resolvedServerOutput === 'module'
+      ? 'import'
+      : federation
+        ? 'async-node'
+        : 'require';
+
+  api.modifyRspackConfig((rspackConfig, { environment, mergeConfig }) => {
+    if (environment.name === 'web') {
+      return mergeConfig(rspackConfig, {
+        output: {
+          ...webOutput,
+          ...(federation ? { chunkLoading: 'import' } : {}),
+        },
+      });
+    }
+    if (environment.name === 'node') {
+      return mergeConfig(rspackConfig, {
+        output: {
+          chunkFormat: resolvedServerOutput,
+          chunkLoading: nodeChunkLoading,
+          devtoolModuleFilenameTemplate: '[absolute-resource-path]',
+          devtoolFallbackModuleFilenameTemplate:
+            '[absolute-resource-path]?[hash]',
+          workerChunkLoading: nodeChunkLoading,
+          wasmLoading: 'fetch',
+          module: resolvedServerOutput === 'module',
+          chunkFilename: 'static/js/async/[name].js',
+        },
+      });
+    }
+    return rspackConfig;
+  });
+
   api.modifyEnvironmentConfig(
     async (config, { name, mergeEnvironmentConfig }) => {
       if (name !== 'web' && name !== 'node') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,15 +223,21 @@ export const pluginReactRouter = (
     });
 
     // The manifest / server `publicPath` follows the web environment's asset
-    // prefix (which inherits the root one) because that is where the browser
-    // assets are actually served from.
+    // prefix because that is where the browser assets are served from. A web
+    // prefix the server cannot use (`'auto'`) falls back to the root prefix,
+    // so `output.assetPrefix: 'https://cdn/'` + web `'auto'` still emits CDN
+    // URLs from the server.
     api.onBeforeCreateCompiler(() => {
-      const normalized = api.getNormalizedConfig({ environment: 'web' });
-      assetPrefix = resolveEffectiveAssetPrefix({
-        dev: normalized.dev,
-        output: normalized.output,
-        isBuild: api.context.action === 'build',
-      });
+      const web = api.getNormalizedConfig({ environment: 'web' });
+      const root = api.getNormalizedConfig();
+      assetPrefix = resolveEffectiveAssetPrefix(
+        {
+          dev: web.dev,
+          output: web.output,
+          isBuild: api.context.action === 'build',
+        },
+        { dev: root.dev, output: root.output }
+      );
     });
 
     const configPath = findEntryFile(resolve('react-router.config'));
@@ -844,19 +850,12 @@ export const pluginReactRouter = (
       );
     };
 
-    const useAsyncNodeChunkLoading =
-      options.federation && resolvedServerOutput === 'commonjs';
-    let nodeChunkLoading: 'import' | 'async-node' | 'require' = 'require';
-    if (resolvedServerOutput === 'module') {
-      nodeChunkLoading = 'import';
-    } else if (useAsyncNodeChunkLoading) {
-      nodeChunkLoading = 'async-node';
-    }
-    // Set when the user configures web `output.filename.js`: Rsbuild derives the
-    // async chunk filename from it, so the plugin's own `chunkFilename` default
-    // must step aside to honor the user's naming scheme (#129).
-    let hasUserWebJsFilename = false;
-
+    const nodeChunkLoading =
+      resolvedServerOutput === 'module'
+        ? 'import'
+        : options.federation
+          ? 'async-node'
+          : 'require';
     api.modifyRsbuildConfig(async (config, { mergeRsbuildConfig }) => {
       const webConfig = config.environments?.web;
       // Fallback location of the RSC browser entry when the RSC manifest does
@@ -867,14 +866,10 @@ export const pluginReactRouter = (
         (typeof webDistPath === 'object' ? webDistPath.js : undefined) ??
         (typeof rootDistPath === 'object' ? rootDistPath.js : undefined) ??
         DEFAULT_JS_DIST_PATH;
-      hasUserWebJsFilename =
-        (webConfig?.output?.filename?.js ?? config.output?.filename?.js) !==
-        undefined;
-      const assetPrefix = resolveEffectiveAssetPrefix({
-        dev: { ...config.dev, ...webConfig?.dev },
-        output: { ...config.output, ...webConfig?.output },
-        isBuild,
-      });
+      const assetPrefix = resolveEffectiveAssetPrefix(
+        { dev: webConfig?.dev, output: webConfig?.output, isBuild },
+        { dev: config.dev, output: config.output }
+      );
       const vmodPlugin = createVirtualModulePlugin(assetPrefix, jsDistPath);
       const configuredLazyCompilation = Object.prototype.hasOwnProperty.call(
         options,
@@ -1047,18 +1042,15 @@ export const pluginReactRouter = (
     // Rspack `output` defaults are applied here instead of through the merged
     // `tools.rspack` object above: Rsbuild runs the user's `tools.rspack`
     // (object or function form) after `modifyRspackConfig`, so user output
-    // settings such as `filename`, `chunkFilename`, or `publicPath` always win
-    // (#129, #130). `publicPath` is deliberately not set; Rsbuild derives it
-    // from the environment's `output.assetPrefix`, which keeps `'auto'` intact.
+    // settings such as `chunkFilename` take precedence over these defaults
+    // (#129, #130). Neither `filename` nor `publicPath` is set: Rsbuild derives
+    // them from `output.filename`/`output.filenameHash`/`output.distPath` and
+    // the environment's `output.assetPrefix`, which keeps `'auto'` intact.
     api.modifyRspackConfig((rspackConfig, { environment, mergeConfig }) => {
       if (environment.name === 'web') {
-        const { chunkFilename, ...webOutput } = modePlan.webOutput;
         return mergeConfig(rspackConfig, {
           output: {
-            ...webOutput,
-            ...(chunkFilename !== undefined && !hasUserWebJsFilename
-              ? { chunkFilename }
-              : {}),
+            ...modePlan.webOutput,
             ...(options.federation ? { chunkLoading: 'import' } : {}),
           },
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,7 @@ import { rspack, type RsbuildPlugin, type Rspack } from '@rsbuild/core';
 import { relative, resolve } from 'pathe';
 
 import { getDefaultConcurrency } from './concurrency.js';
-import {
-  DEFAULT_JS_DIST_PATH,
-  JS_EXTENSIONS,
-  PLUGIN_NAME,
-} from './constants.js';
+import { JS_EXTENSIONS, PLUGIN_NAME } from './constants.js';
 import { guardReactRouterLazyCompilation } from './lazy-compilation.js';
 import {
   findEntryFile,
@@ -228,12 +224,15 @@ export const pluginReactRouter = (
     // so `output.assetPrefix: 'https://cdn/'` + web `'auto'` still emits CDN
     // URLs from the server.
     api.onBeforeCreateCompiler(() => {
-      const web = api.getNormalizedConfig({ environment: 'web' });
       const root = api.getNormalizedConfig();
+      // `getNormalizedConfig({ environment: 'web' })` throws when the build was
+      // narrowed to other environments (`--environment node`), so look the web
+      // environment up on the root config instead.
+      const web = root.environments.web;
       assetPrefix = resolveEffectiveAssetPrefix(
         {
-          dev: web.dev,
-          output: web.output,
+          dev: web?.dev,
+          output: web?.output,
           isBuild: api.context.action === 'build',
         },
         { dev: root.dev, output: root.output }
@@ -841,36 +840,35 @@ export const pluginReactRouter = (
     }
 
     // Public requests stay bare while Rspack resolves seeded virtual files.
-    const createVirtualModulePlugin = (
-      publicPath: string,
-      jsDistPath: string
-    ) => {
+    const createVirtualModulePlugin = (publicPath: string) => {
       return new rspack.experiments.VirtualModulesPlugin(
-        mapVirtualModules(modePlan.createVirtualModules(publicPath, jsDistPath))
+        mapVirtualModules(modePlan.createVirtualModules(publicPath))
       );
     };
 
-    const nodeChunkLoading =
-      resolvedServerOutput === 'module'
-        ? 'import'
-        : options.federation
-          ? 'async-node'
-          : 'require';
     api.modifyRsbuildConfig(async (config, { mergeRsbuildConfig }) => {
       const webConfig = config.environments?.web;
-      // Fallback location of the RSC browser entry when the RSC manifest does
-      // not report `entryJsFiles`; see `createReactRouterRscVirtualModules`.
-      const webDistPath = webConfig?.output?.distPath;
-      const rootDistPath = config.output?.distPath;
-      const jsDistPath =
-        (typeof webDistPath === 'object' ? webDistPath.js : undefined) ??
-        (typeof rootDistPath === 'object' ? rootDistPath.js : undefined) ??
-        DEFAULT_JS_DIST_PATH;
+      const webJsFilename =
+        webConfig?.output?.filename?.js ?? config.output?.filename?.js;
+      // Rspack's RSC manifest only records browser entry files named `*.js`
+      // (`entryJsFiles`), and the server renders its bootstrap scripts from
+      // that list. Reject filename schemes it would silently drop up front.
+      if (
+        isRscMode &&
+        typeof webJsFilename === 'string' &&
+        !/\.js$/.test(webJsFilename)
+      ) {
+        throw new Error(
+          `[${PLUGIN_NAME}] RSC mode requires web \`output.filename.js\` to end in ".js" (got ${JSON.stringify(
+            webJsFilename
+          )}): rspack's RSC manifest omits entry files with a query or another extension, so the server could not render bootstrap scripts.`
+        );
+      }
       const assetPrefix = resolveEffectiveAssetPrefix(
         { dev: webConfig?.dev, output: webConfig?.output, isBuild },
         { dev: config.dev, output: config.output }
       );
-      const vmodPlugin = createVirtualModulePlugin(assetPrefix, jsDistPath);
+      const vmodPlugin = createVirtualModulePlugin(assetPrefix);
       const configuredLazyCompilation = Object.prototype.hasOwnProperty.call(
         options,
         'lazyCompilation'
@@ -1039,44 +1037,11 @@ export const pluginReactRouter = (
       });
     });
 
-    // Rspack `output` defaults are applied here instead of through the merged
-    // `tools.rspack` object above: Rsbuild runs the user's `tools.rspack`
-    // (object or function form) after `modifyRspackConfig`, so user output
-    // settings such as `chunkFilename` take precedence over these defaults
-    // (#129, #130). Neither `filename` nor `publicPath` is set: Rsbuild derives
-    // them from `output.filename`/`output.filenameHash`/`output.distPath` and
-    // the environment's `output.assetPrefix`, which keeps `'auto'` intact.
-    api.modifyRspackConfig((rspackConfig, { environment, mergeConfig }) => {
-      if (environment.name === 'web') {
-        return mergeConfig(rspackConfig, {
-          output: {
-            ...modePlan.webOutput,
-            ...(options.federation ? { chunkLoading: 'import' } : {}),
-          },
-        });
-      }
-      if (environment.name === 'node') {
-        return mergeConfig(rspackConfig, {
-          output: {
-            chunkFormat: resolvedServerOutput,
-            chunkLoading: nodeChunkLoading,
-            devtoolModuleFilenameTemplate: '[absolute-resource-path]',
-            devtoolFallbackModuleFilenameTemplate:
-              '[absolute-resource-path]?[hash]',
-            workerChunkLoading: nodeChunkLoading,
-            wasmLoading: 'fetch',
-            module: resolvedServerOutput === 'module',
-            chunkFilename: 'static/js/async/[name].js',
-          },
-        });
-      }
-      return rspackConfig;
-    });
-
     registerReactRouterEnvironmentOutput({
       api,
       federation: pluginOptions.federation,
       resolvedServerOutput,
+      webOutput: modePlan.webOutput,
     });
 
     if (modePlan.kind === 'classic' && useRouteModuleTransformLoader) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,8 +222,11 @@ export const pluginReactRouter = (
       warnOnClientSourceMaps(normalized, msg => api.logger.warn(msg), 'web');
     });
 
+    // The manifest / server `publicPath` follows the web environment's asset
+    // prefix (which inherits the root one) because that is where the browser
+    // assets are actually served from.
     api.onBeforeCreateCompiler(() => {
-      const normalized = api.getNormalizedConfig();
+      const normalized = api.getNormalizedConfig({ environment: 'web' });
       assetPrefix = resolveEffectiveAssetPrefix({
         dev: normalized.dev,
         output: normalized.output,
@@ -841,30 +844,38 @@ export const pluginReactRouter = (
       );
     };
 
+    const useAsyncNodeChunkLoading =
+      options.federation && resolvedServerOutput === 'commonjs';
+    let nodeChunkLoading: 'import' | 'async-node' | 'require' = 'require';
+    if (resolvedServerOutput === 'module') {
+      nodeChunkLoading = 'import';
+    } else if (useAsyncNodeChunkLoading) {
+      nodeChunkLoading = 'async-node';
+    }
+    // Set when the user configures web `output.filename.js`: Rsbuild derives the
+    // async chunk filename from it, so the plugin's own `chunkFilename` default
+    // must step aside to honor the user's naming scheme (#129).
+    let hasUserWebJsFilename = false;
+
     api.modifyRsbuildConfig(async (config, { mergeRsbuildConfig }) => {
-      // The RSC bootstrap script URL must reflect the user's web js distPath;
-      // the entry filename itself is deterministic because the plugin forces
-      // web `output.filename.js` to '[name].js' below.
-      const webDistPath = config.environments?.web?.output?.distPath;
+      const webConfig = config.environments?.web;
+      // Fallback location of the RSC browser entry when the RSC manifest does
+      // not report `entryJsFiles`; see `createReactRouterRscVirtualModules`.
+      const webDistPath = webConfig?.output?.distPath;
       const rootDistPath = config.output?.distPath;
       const jsDistPath =
         (typeof webDistPath === 'object' ? webDistPath.js : undefined) ??
         (typeof rootDistPath === 'object' ? rootDistPath.js : undefined) ??
         DEFAULT_JS_DIST_PATH;
+      hasUserWebJsFilename =
+        (webConfig?.output?.filename?.js ?? config.output?.filename?.js) !==
+        undefined;
       const assetPrefix = resolveEffectiveAssetPrefix({
-        dev: config.dev,
-        output: config.output,
+        dev: { ...config.dev, ...webConfig?.dev },
+        output: { ...config.output, ...webConfig?.output },
         isBuild,
       });
       const vmodPlugin = createVirtualModulePlugin(assetPrefix, jsDistPath);
-      const useAsyncNodeChunkLoading =
-        options.federation && resolvedServerOutput === 'commonjs';
-      let nodeChunkLoading: 'import' | 'async-node' | 'require' = 'require';
-      if (resolvedServerOutput === 'module') {
-        nodeChunkLoading = 'import';
-      } else if (useAsyncNodeChunkLoading) {
-        nodeChunkLoading = 'async-node';
-      }
       const configuredLazyCompilation = Object.prototype.hasOwnProperty.call(
         options,
         'lazyCompilation'
@@ -964,9 +975,6 @@ export const pluginReactRouter = (
                   }),
             },
             output: {
-              filename: {
-                js: '[name].js',
-              },
               distPath: {
                 root: outputClientPath,
               },
@@ -985,15 +993,6 @@ export const pluginReactRouter = (
                   ],
                 },
                 externalsType: modePlan.webExternalsType,
-                output: {
-                  ...modePlan.webOutput,
-                  publicPath: assetPrefix,
-                  ...(options.federation
-                    ? {
-                        chunkLoading: 'import',
-                      }
-                    : {}),
-                },
                 optimization: modePlan.webOptimization,
               },
             },
@@ -1038,22 +1037,48 @@ export const pluginReactRouter = (
                 externals: modePlan.nodeExternals,
                 ...modePlan.nodeDependencies,
                 externalsType: resolvedServerOutput,
-                output: {
-                  chunkFormat: resolvedServerOutput,
-                  chunkLoading: nodeChunkLoading,
-                  devtoolModuleFilenameTemplate: '[absolute-resource-path]',
-                  devtoolFallbackModuleFilenameTemplate:
-                    '[absolute-resource-path]?[hash]',
-                  workerChunkLoading: nodeChunkLoading,
-                  wasmLoading: 'fetch',
-                  module: resolvedServerOutput === 'module',
-                  chunkFilename: 'static/js/async/[name].js',
-                },
               },
             },
           },
         },
       });
+    });
+
+    // Rspack `output` defaults are applied here instead of through the merged
+    // `tools.rspack` object above: Rsbuild runs the user's `tools.rspack`
+    // (object or function form) after `modifyRspackConfig`, so user output
+    // settings such as `filename`, `chunkFilename`, or `publicPath` always win
+    // (#129, #130). `publicPath` is deliberately not set; Rsbuild derives it
+    // from the environment's `output.assetPrefix`, which keeps `'auto'` intact.
+    api.modifyRspackConfig((rspackConfig, { environment, mergeConfig }) => {
+      if (environment.name === 'web') {
+        const { chunkFilename, ...webOutput } = modePlan.webOutput;
+        return mergeConfig(rspackConfig, {
+          output: {
+            ...webOutput,
+            ...(chunkFilename !== undefined && !hasUserWebJsFilename
+              ? { chunkFilename }
+              : {}),
+            ...(options.federation ? { chunkLoading: 'import' } : {}),
+          },
+        });
+      }
+      if (environment.name === 'node') {
+        return mergeConfig(rspackConfig, {
+          output: {
+            chunkFormat: resolvedServerOutput,
+            chunkLoading: nodeChunkLoading,
+            devtoolModuleFilenameTemplate: '[absolute-resource-path]',
+            devtoolFallbackModuleFilenameTemplate:
+              '[absolute-resource-path]?[hash]',
+            workerChunkLoading: nodeChunkLoading,
+            wasmLoading: 'fetch',
+            module: resolvedServerOutput === 'module',
+            chunkFilename: 'static/js/async/[name].js',
+          },
+        });
+      }
+      return rspackConfig;
     });
 
     registerReactRouterEnvironmentOutput({

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -167,26 +167,17 @@ type ReactRouterManifestStatsCompilation = {
   entrypoints?: ReactRouterManifestStatsLookup<ReactRouterManifestStatsEntrypoint>;
 };
 
-const escapeRegExp = (value: string): string =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+// Emitted asset names may carry a query (`output.filename.js:
+// '[name].js?v=[contenthash:8]'`); classify on the pathname but keep the full
+// reference, since the query is part of the URL the browser must request.
+// A chunk's own script is whatever JavaScript the compilation rendered for it,
+// regardless of `output.filename` scheme. In development, HMR update files are
+// also recorded on `chunk.files`; they are never the module to load.
+export const isManifestJsAsset = (asset: string): boolean =>
+  /(?<!\.hot-update)\.js(?:\?.*)?$/.test(asset);
 
-const orderChunkFiles = (chunkName: string, files: string[]): string[] => {
-  // Match `<dir>/<chunkName>.js` as well as hashed variants such as
-  // `<chunkName>.abc12345.js` or `<chunkName>-abc12345.js`.
-  const ownChunkAsset = new RegExp(
-    `(?:^|/)${escapeRegExp(chunkName)}(?:[.-][^/]*)?\\.js$`
-  );
-  const ownFileIndex = files.findIndex(file => ownChunkAsset.test(file));
-  if (ownFileIndex <= 0) {
-    return files;
-  }
-
-  return [
-    files[ownFileIndex],
-    ...files.slice(0, ownFileIndex),
-    ...files.slice(ownFileIndex + 1),
-  ];
-};
+export const isManifestCssAsset = (asset: string): boolean =>
+  /\.css(?:\?.*)?$/.test(asset);
 
 const collectManifestFilesByName = <T>(
   items: ReactRouterManifestStatsLookup<T>,
@@ -248,8 +239,7 @@ export const createReactRouterManifestStats = (
   const assetsByChunkName = collectManifestFilesByName(
     compilation.namedChunks,
     chunkNames,
-    (chunkName, chunk) =>
-      orderChunkFiles(chunkName, Array.from(chunk.files ?? []))
+    (_chunkName, chunk) => Array.from(chunk.files ?? [])
   );
   const entrypointFilesByName = compilation.entrypoints
     ? collectManifestFilesByName(
@@ -310,17 +300,19 @@ const createChunkAssetResolver = (
 
     const cssAssets = new Set<string>();
     const jsAssets = new Set<string>();
+    // The chunk's own files come first so `js[0]` is the route module itself;
+    // entrypoint files (runtime, shared vendor chunks) follow as `imports`.
     for (const asset of assets) {
-      if (asset.endsWith('.css')) {
+      if (isManifestCssAsset(asset)) {
         cssAssets.add(asset);
-      } else if (asset.endsWith('.js')) {
+      } else if (isManifestJsAsset(asset)) {
         jsAssets.add(asset);
       }
     }
     for (const asset of clientStats?.entrypointFilesByName?.[chunkName] ?? []) {
-      if (asset.endsWith('.css')) {
+      if (isManifestCssAsset(asset)) {
         cssAssets.add(asset);
-      } else if (includeEntrypointJs && asset.endsWith('.js')) {
+      } else if (includeEntrypointJs && isManifestJsAsset(asset)) {
         jsAssets.add(asset);
       }
     }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -174,7 +174,7 @@ type ReactRouterManifestStatsCompilation = {
 // regardless of `output.filename` scheme. In development, HMR update files are
 // also recorded on `chunk.files`; they are never the module to load.
 export const isManifestJsAsset = (asset: string): boolean =>
-  /(?<!\.hot-update)\.js(?:\?.*)?$/.test(asset);
+  /(?<!\.hot-update)\.[cm]?js(?:\?.*)?$/.test(asset);
 
 export const isManifestCssAsset = (asset: string): boolean =>
   /\.css(?:\?.*)?$/.test(asset);
@@ -317,7 +317,14 @@ const createChunkAssetResolver = (
       }
     }
     if (jsAssets.size === 0) {
-      jsAssets.add(`${DEFAULT_MANIFEST_DIR}/${chunkName}.js`);
+      // Compilation metadata exists for this chunk but names no module script.
+      // Guessing `<dir>/<chunk>.js` here would turn an identifiable build
+      // problem into a browser 404, so surface it at build time instead.
+      throw new Error(
+        `[react-router] Chunk "${chunkName}" emitted no JavaScript asset the browser manifest can reference (files: ${
+          assets.join(', ') || 'none'
+        }). Check the web \`output.filename.js\` scheme.`
+      );
     }
 
     const result = { js: [...jsAssets], css: [...cssAssets] };

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -167,9 +167,16 @@ type ReactRouterManifestStatsCompilation = {
   entrypoints?: ReactRouterManifestStatsLookup<ReactRouterManifestStatsEntrypoint>;
 };
 
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const orderChunkFiles = (chunkName: string, files: string[]): string[] => {
-  const ownChunkAsset = `${chunkName}.js`;
-  const ownFileIndex = files.findIndex(file => file.endsWith(ownChunkAsset));
+  // Match `<dir>/<chunkName>.js` as well as hashed variants such as
+  // `<chunkName>.abc12345.js` or `<chunkName>-abc12345.js`.
+  const ownChunkAsset = new RegExp(
+    `(?:^|/)${escapeRegExp(chunkName)}(?:[.-][^/]*)?\\.js$`
+  );
+  const ownFileIndex = files.findIndex(file => ownChunkAsset.test(file));
   if (ownFileIndex <= 0) {
     return files;
   }

--- a/src/mode-plan.ts
+++ b/src/mode-plan.ts
@@ -349,11 +349,9 @@ const createClassicModePlan = async ({
       wasmLoading: 'fetch',
       library: { type: 'module' },
       module: true,
-      // Async chunks are addressed by id at runtime, so the chunk name only
-      // adds bytes to the filename and to every place that references it.
-      ...(isBuild
-        ? { chunkFilename: 'static/js/async/[id]-[contenthash:16].js' }
-        : {}),
+      // Async chunk filenames are left to Rsbuild, which derives them from
+      // `output.filename.js`, `output.filenameHash`, and `distPath.jsAsync`,
+      // so user configuration governs every JavaScript filename (#129).
     },
     webOptimization: {
       avoidEntryIife: true,

--- a/src/mode-plan.ts
+++ b/src/mode-plan.ts
@@ -36,10 +36,7 @@ type CommonModePlan = {
   manifestChunkNames: Set<string>;
   webEntries: Record<string, string | RsbuildEntryDescription>;
   nodeEntries: Record<string, string | RsbuildEntryDescription>;
-  createVirtualModules(
-    publicPath: string,
-    jsDistPath: string
-  ): Record<string, string>;
+  createVirtualModules(publicPath: string): Record<string, string>;
   createResolveConfig(rootPath: string): Rspack.Configuration['resolve'];
   server: RsbuildConfig['server'] | undefined;
   webExternalsType: 'module' | undefined;
@@ -183,14 +180,13 @@ const createRscModePlan = async ({
         layer: RSC_LAYERS.rsc,
       },
     },
-    createVirtualModules: (publicPath: string, jsDistPath: string) =>
+    createVirtualModules: (publicPath: string) =>
       createReactRouterRscVirtualModules({
         allowedActionOrigins: allowedActionOriginsForBuild,
         appDirectory,
         basename,
         buildDirectory,
         isBuild,
-        jsDistPath,
         outputClientPath,
         publicPath,
         routeDiscovery,
@@ -314,7 +310,7 @@ const createClassicModePlan = async ({
       defaultEntryName,
       serverBundleEntries: artifacts.serverBundleEntries,
     }),
-    createVirtualModules: (publicPath: string, _jsDistPath: string) =>
+    createVirtualModules: (publicPath: string) =>
       createClassicVirtualModules({
         allowedActionOrigins: allowedActionOriginsForBuild,
         appDirectory,

--- a/src/modify-browser-manifest.ts
+++ b/src/modify-browser-manifest.ts
@@ -7,6 +7,7 @@ import {
   generateReactRouterManifestForDev,
   getReactRouterManifestChunkNames,
   getReactRouterManifestPath,
+  isManifestJsAsset,
   type ReactRouterManifestForDev as ReactRouterManifest,
   type RouteChunkManifestOptions,
   type RouteManifestModuleExports,
@@ -83,7 +84,7 @@ const addIntegrity = (
 ) => {
   if (
     typeof assetName !== 'string' ||
-    !assetName.endsWith('.js') ||
+    !isManifestJsAsset(assetName) ||
     typeof integrity !== 'string'
   ) {
     return;
@@ -117,7 +118,7 @@ export const collectSubresourceIntegrity = (
     const assets =
       compilation.getAssets() as readonly CompilationAssetWithIntegrity[];
     for (const asset of assets) {
-      if (!asset.name.endsWith('.js')) {
+      if (!isManifestJsAsset(asset.name)) {
         continue;
       }
       addIntegrity(
@@ -200,8 +201,7 @@ export function registerModifyBrowserManifestAssets(
 
     if (isBuild) {
       const entryAssets = stats?.assetsByChunkName?.['entry.client'];
-      const entryJsAssets =
-        entryAssets?.filter(asset => asset.endsWith('.js')) || [];
+      const entryJsAssets = entryAssets?.filter(isManifestJsAsset) || [];
       const manifestPath = getReactRouterManifestPath({
         version: manifest.version,
         isBuild: true,

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -79,34 +79,48 @@ export function normalizeAssetPrefix(assetPrefix?: string): string {
   return assetPrefix.endsWith('/') ? assetPrefix : `${assetPrefix}/`;
 }
 
-/**
- * Resolve the asset prefix Rsbuild applies to emitted asset URLs for the given
- * mode. In development the effective prefix is `dev.assetPrefix` (which Rsbuild
- * defaults from `server.base`, falling back to `output.assetPrefix`); in a
- * production build it is `output.assetPrefix`. Both fields are already resolved
- * on the normalized config, so this mirrors Rsbuild's own precedence rather than
- * re-deriving it from `server.base`.
- *
- * `dev.assetPrefix` may be a boolean on the raw config (`false` disables it);
- * boolean/`'auto'`/empty values normalize to the root prefix `'/'`.
- */
-export function resolveEffectiveAssetPrefix(config: {
+type AssetPrefixConfig = {
   dev?: { assetPrefix?: unknown };
   output?: { assetPrefix?: unknown };
-  isBuild: boolean;
-}): string {
-  const outputPrefix =
-    typeof config.output?.assetPrefix === 'string'
-      ? config.output.assetPrefix
-      : undefined;
-  if (config.isBuild) {
-    return normalizeAssetPrefix(outputPrefix);
+};
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' ? value : undefined;
+
+const pickConfiguredAssetPrefix = (
+  { dev, output }: AssetPrefixConfig,
+  isBuild: boolean
+): string | undefined =>
+  isBuild
+    ? asString(output?.assetPrefix)
+    : (asString(dev?.assetPrefix) ?? asString(output?.assetPrefix));
+
+/**
+ * Resolve the absolute asset prefix the server build and browser manifest use
+ * for asset URLs. In development the effective prefix is `dev.assetPrefix`
+ * (which Rsbuild defaults from `server.base`, falling back to
+ * `output.assetPrefix`); in a production build it is `output.assetPrefix`.
+ *
+ * `fallbacks` are consulted in order (e.g. the root config after the web
+ * environment) when the preceding config only offers a prefix the server
+ * cannot use: `'auto'` and empty values are browser-runtime-only, so a root
+ * CDN prefix must survive a web `'auto'`. The choice happens before
+ * normalization so that `'auto'` is not first folded into `'/'`.
+ *
+ * `dev.assetPrefix` may be a boolean on the raw config (`false` disables it);
+ * boolean/`'auto'`/empty values ultimately normalize to the root prefix `'/'`.
+ */
+export function resolveEffectiveAssetPrefix(
+  config: AssetPrefixConfig & { isBuild: boolean },
+  ...fallbacks: AssetPrefixConfig[]
+): string {
+  for (const candidate of [config, ...fallbacks]) {
+    const prefix = pickConfiguredAssetPrefix(candidate, config.isBuild);
+    if (prefix && prefix !== 'auto') {
+      return normalizeAssetPrefix(prefix);
+    }
   }
-  const devPrefix =
-    typeof config.dev?.assetPrefix === 'string'
-      ? config.dev.assetPrefix
-      : undefined;
-  return normalizeAssetPrefix(devPrefix ?? outputPrefix);
+  return '/';
 }
 
 export function createRouteId(file: string): string {

--- a/src/rsc-route-transforms.ts
+++ b/src/rsc-route-transforms.ts
@@ -623,6 +623,12 @@ const createServerRouteEntry = async (
   let needsReactImport = false;
   let needsEnsureHmrImport = false;
   let needsStyleEntryImport = false;
+  const pushStylesheetLinks = (entryCssFilesExpression: string): void => {
+    lines.push(`    ...(${entryCssFilesExpression} ?? []).map(href =>`);
+    lines.push(
+      '      React.createElement("link", { key: href, rel: "stylesheet", href: href, precedence: "default" })),'
+    );
+  };
 
   // A client route whose default component is a client reference: its bundled
   // (non-vanilla) side-effect CSS is orphaned in the initial browser entry
@@ -651,12 +657,7 @@ const createServerRouteEntry = async (
         'export default function RscClientRouteWithStyles___(props) {'
       );
       lines.push('  return React.createElement(React.Fragment, null,');
-      lines.push(
-        `    ...(${RSC_ROUTE_STYLE_ENTRY_EXPORT}.entryCssFiles ?? []).map(href =>`
-      );
-      lines.push(
-        '      React.createElement("link", { key: href, rel: "stylesheet", href: href, precedence: "default" })),'
-      );
+      pushStylesheetLinks(`${RSC_ROUTE_STYLE_ENTRY_EXPORT}.entryCssFiles`);
       lines.push('    React.createElement(RscClientRouteDefault___, props),');
       lines.push('  );');
       lines.push('}');
@@ -682,12 +683,7 @@ const createServerRouteEntry = async (
       // graph contributes. Render those as stylesheet links at the top of the
       // stream (mirrors upstream's `import.meta.viteRsc.loadCss()`); React's
       // float support hoists them into `<head>`.
-      lines.push(
-        `    ...(${exportName}WithoutClientChunk.entryCssFiles ?? []).map(href =>`
-      );
-      lines.push(
-        '      React.createElement("link", { key: href, rel: "stylesheet", href: href, precedence: "default" })),'
-      );
+      pushStylesheetLinks(`${exportName}WithoutClientChunk.entryCssFiles`);
       lines.push(
         '    React.createElement(EnsureClientRouteModuleForHMR___, null),'
       );

--- a/src/rsc-virtual-modules.ts
+++ b/src/rsc-virtual-modules.ts
@@ -84,7 +84,12 @@ export const createReactRouterRscVirtualModules = ({
     resolve(buildDirectory, 'server'),
     outputClientPath
   );
-  const bootstrapPublicPath = normalizeAssetPrefix(publicPath);
+  // Fallback only: the compiled browser entry name is not deterministic once
+  // the user (or Rsbuild's production default) content-hashes `filename.js`.
+  const fallbackBootstrapScript = combineURLs(
+    normalizeAssetPrefix(publicPath),
+    `${jsDistPath}/index.js`
+  );
 
   return {
     'virtual/react-router/unstable_rsc/routes': createRscRouteConfig({
@@ -111,9 +116,13 @@ export const createReactRouterRscVirtualModules = ({
         assetsBuildDirectory: rscAssetsBuildDirectory,
         publicPath,
       }),
-    'virtual/react-router/unstable_rsc/bootstrap-scripts': defaultExport([
-      combineURLs(bootstrapPublicPath, `${jsDistPath}/index.js`),
-    ]),
+    // The rspack RSC manifest records the compiled browser entry files, already
+    // prefixed with the web `publicPath` (like Next's `buildManifest` or the
+    // Vite plugin's `loadBootstrapScriptContent`), so hashed entry filenames
+    // and per-environment asset prefixes resolve without any naming contract.
+    'virtual/react-router/unstable_rsc/bootstrap-scripts': `const entryJsFiles = __webpack_require__.rscM?.entryJsFiles;
+export default entryJsFiles?.length ? entryJsFiles : ${JSON.stringify([fallbackBootstrapScript])};
+`,
     'virtual/react-router/unstable_rsc/server-manifest': `export default function getServerManifest() {
   return __webpack_require__.rscM?.serverManifest;
 }

--- a/src/rsc-virtual-modules.ts
+++ b/src/rsc-virtual-modules.ts
@@ -84,10 +84,14 @@ export const createReactRouterRscVirtualModules = ({
     resolve(buildDirectory, 'server'),
     outputClientPath
   );
+  // Absolute prefix the server must use for initial asset URLs (see
+  // `resolveEffectiveAssetPrefix`); the browser compiler may itself be on
+  // `'auto'`, which no server-rendered URL can express.
+  const serverPublicPath = normalizeAssetPrefix(publicPath);
   // Fallback only: the compiled browser entry name is not deterministic once
   // the user (or Rsbuild's production default) content-hashes `filename.js`.
   const fallbackBootstrapScript = combineURLs(
-    normalizeAssetPrefix(publicPath),
+    serverPublicPath,
     `${jsDistPath}/index.js`
   );
 
@@ -116,12 +120,26 @@ export const createReactRouterRscVirtualModules = ({
         assetsBuildDirectory: rscAssetsBuildDirectory,
         publicPath,
       }),
-    // The rspack RSC manifest records the compiled browser entry files, already
-    // prefixed with the web `publicPath` (like Next's `buildManifest` or the
-    // Vite plugin's `loadBootstrapScriptContent`), so hashed entry filenames
-    // and per-environment asset prefixes resolve without any naming contract.
-    'virtual/react-router/unstable_rsc/bootstrap-scripts': `const entryJsFiles = __webpack_require__.rscM?.entryJsFiles;
-export default entryJsFiles?.length ? entryJsFiles : ${JSON.stringify([fallbackBootstrapScript])};
+    // The rspack RSC manifest records the compiled browser entry files (like
+    // Next's `buildManifest` or the Vite plugin's `loadBootstrapScriptContent`),
+    // already prefixed with the prefix it reports in `moduleLoading.prefix`, so
+    // hashed entry filenames resolve without any naming contract. When that
+    // applied prefix differs from the server prefix (the browser compiler is on
+    // `'auto'`, which rspack records as `/`), swap it for the server prefix
+    // instead of stacking a second one; the list and its order are preserved.
+    'virtual/react-router/unstable_rsc/bootstrap-scripts': `const manifest = __webpack_require__.rscM;
+const entryJsFiles = manifest?.entryJsFiles;
+const appliedPrefix = manifest?.moduleLoading?.prefix;
+const serverPrefix = ${JSON.stringify(serverPublicPath)};
+export default !entryJsFiles?.length
+  ? ${JSON.stringify([fallbackBootstrapScript])}
+  : appliedPrefix && appliedPrefix !== serverPrefix
+    ? entryJsFiles.map(file =>
+        file.startsWith(appliedPrefix)
+          ? serverPrefix + file.slice(appliedPrefix.length)
+          : file
+      )
+    : entryJsFiles;
 `,
     'virtual/react-router/unstable_rsc/server-manifest': `export default function getServerManifest() {
   return __webpack_require__.rscM?.serverManifest;

--- a/src/rsc-virtual-modules.ts
+++ b/src/rsc-virtual-modules.ts
@@ -1,7 +1,7 @@
 import { relative, resolve } from 'pathe';
 import type { Config } from './react-router-config.js';
 import type { Route } from './types.js';
-import { combineURLs, normalizeAssetPrefix } from './plugin-utils.js';
+import { normalizeAssetPrefix } from './plugin-utils.js';
 import { getVirtualModuleFilePath } from './virtual-modules.js';
 import {
   createRscInternalClientModule,
@@ -19,6 +19,7 @@ const RSC_VIRTUAL_ALIAS_IDS = [
   'allowed-action-origins',
   'client-version',
   'react-router-serve-config',
+  'manifest-prefix',
   'bootstrap-scripts',
   'server-manifest',
 ] as const;
@@ -29,8 +30,6 @@ type RscVirtualModulesOptions = {
   basename: string;
   buildDirectory: string;
   isBuild: boolean;
-  /** Resolved web `output.distPath.js` segment, e.g. `static/js`. */
-  jsDistPath: string;
   outputClientPath: string;
   publicPath: string;
   routeDiscovery: Config['routeDiscovery'];
@@ -73,7 +72,6 @@ export const createReactRouterRscVirtualModules = ({
   basename,
   buildDirectory,
   isBuild,
-  jsDistPath,
   outputClientPath,
   publicPath,
   routeDiscovery,
@@ -88,12 +86,6 @@ export const createReactRouterRscVirtualModules = ({
   // `resolveEffectiveAssetPrefix`); the browser compiler may itself be on
   // `'auto'`, which no server-rendered URL can express.
   const serverPublicPath = normalizeAssetPrefix(publicPath);
-  // Fallback only: the compiled browser entry name is not deterministic once
-  // the user (or Rsbuild's production default) content-hashes `filename.js`.
-  const fallbackBootstrapScript = combineURLs(
-    serverPublicPath,
-    `${jsDistPath}/index.js`
-  );
 
   return {
     'virtual/react-router/unstable_rsc/routes': createRscRouteConfig({
@@ -120,26 +112,50 @@ export const createReactRouterRscVirtualModules = ({
         assetsBuildDirectory: rscAssetsBuildDirectory,
         publicPath,
       }),
-    // The rspack RSC manifest records the compiled browser entry files (like
-    // Next's `buildManifest` or the Vite plugin's `loadBootstrapScriptContent`),
-    // already prefixed with the prefix it reports in `moduleLoading.prefix`, so
-    // hashed entry filenames resolve without any naming contract. When that
-    // applied prefix differs from the server prefix (the browser compiler is on
-    // `'auto'`, which rspack records as `/`), swap it for the server prefix
-    // instead of stacking a second one; the list and its order are preserved.
-    'virtual/react-router/unstable_rsc/bootstrap-scripts': `const manifest = __webpack_require__.rscM;
-const entryJsFiles = manifest?.entryJsFiles;
-const appliedPrefix = manifest?.moduleLoading?.prefix;
+    // Every server-facing asset URL in the rspack RSC manifest -- bootstrap
+    // `entryJsFiles`, route `entryCssFiles`, client references' `cssFiles`
+    // (react-server-dom-rspack renders those as <link>s), and Flight's
+    // `moduleLoading.prefix` for client-chunk preloads -- carries the browser
+    // compiler's public path, recorded in `moduleLoading.prefix`. With the
+    // browser compiler on `'auto'` rspack records `/`, which the server cannot
+    // serve from. `__rspack_rsc_manifest__` is this same object, so aligning
+    // it once, in place (arrays are mutated, not replaced, because
+    // `createServerEntry` has already captured references), makes every
+    // consumer agree on the server prefix without stacking a second one. The
+    // aligned manifest is exported (not imported for side effects only) so a
+    // `sideEffects: false` package cannot tree-shake the alignment away.
+    'virtual/react-router/unstable_rsc/manifest-prefix': `const manifest = __webpack_require__.rscM;
 const serverPrefix = ${JSON.stringify(serverPublicPath)};
-export default !entryJsFiles?.length
-  ? ${JSON.stringify([fallbackBootstrapScript])}
-  : appliedPrefix && appliedPrefix !== serverPrefix
-    ? entryJsFiles.map(file =>
-        file.startsWith(appliedPrefix)
-          ? serverPrefix + file.slice(appliedPrefix.length)
-          : file
-      )
-    : entryJsFiles;
+const appliedPrefix = manifest?.moduleLoading?.prefix;
+if (appliedPrefix && appliedPrefix !== serverPrefix) {
+  const rewrite = url =>
+    typeof url === "string" && url.startsWith(appliedPrefix)
+      ? serverPrefix + url.slice(appliedPrefix.length)
+      : url;
+  const rewriteAll = list => {
+    if (Array.isArray(list)) for (let i = 0; i < list.length; i++) list[i] = rewrite(list[i]);
+  };
+  manifest.moduleLoading.prefix = serverPrefix;
+  rewriteAll(manifest.entryJsFiles);
+  for (const files of Object.values(manifest.entryCssFiles ?? {})) rewriteAll(files);
+  for (const reference of Object.values(manifest.clientManifest ?? {})) rewriteAll(reference.cssFiles);
+}
+export const rscManifest = manifest;
+`,
+    // The compiled browser entry scripts come from the manifest (like Next's
+    // `buildManifest` or the Vite plugin's `loadBootstrapScriptContent`), so
+    // hashed entry filenames resolve without any naming contract. The list and
+    // its order are preserved. An empty list is a build problem (rspack only
+    // records entry files named `*.js`); fail loudly instead of guessing a
+    // filename that would render a document which cannot hydrate.
+    'virtual/react-router/unstable_rsc/bootstrap-scripts': `import { rscManifest } from "virtual/react-router/unstable_rsc/manifest-prefix";
+const entryJsFiles = rscManifest?.entryJsFiles;
+if (!entryJsFiles?.length) {
+  throw new Error(
+    "[rsbuild-plugin-react-router] The rspack RSC manifest lists no browser entry script (entryJsFiles is empty), so the server cannot render bootstrap scripts. Rspack only records entry files whose name ends in \\".js\\"; web output.filename.js values with a query (for example \\"[name].js?v=[contenthash:8]\\") or another extension are not supported in RSC mode."
+  );
+}
+export default entryJsFiles;
 `,
     'virtual/react-router/unstable_rsc/server-manifest': `export default function getServerManifest() {
   return __webpack_require__.rscM?.serverManifest;

--- a/tests/environment-selection.test.ts
+++ b/tests/environment-selection.test.ts
@@ -1,0 +1,56 @@
+import * as fs from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { createLogger, createRsbuild } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { afterEach, expect, it } from '@rstest/core';
+import { pluginReactRouter } from '../src';
+
+// Real Rsbuild with the build narrowed to one environment (`rsbuild build
+// --environment node`). The plugin must not ask Rsbuild for the `web`
+// environment's normalized config in that case: `getNormalizedConfig({
+// environment })` throws for environments filtered out of the build.
+
+let fixtureRoot: string | undefined;
+const repositoryRoot = process.cwd();
+
+afterEach(() => {
+  process.chdir(repositoryRoot);
+  if (fixtureRoot) {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+    fixtureRoot = undefined;
+  }
+});
+
+it('creates the compiler when only the node environment is selected', async () => {
+  const temporaryFixtures = join(repositoryRoot, 'tests/.tmp-dev-runtime');
+  mkdirSync(temporaryFixtures, { recursive: true });
+  fixtureRoot = mkdtempSync(join(temporaryFixtures, 'env-'));
+  cpSync(join(repositoryRoot, 'tests/fixtures/dev-runtime'), fixtureRoot, {
+    recursive: true,
+  });
+  (fs.existsSync as { mockRestore?: () => void }).mockRestore?.();
+  // The plugin resolves the app directory from the working directory.
+  process.chdir(fixtureRoot);
+
+  const rsbuild = await createRsbuild({
+    cwd: fixtureRoot,
+    environment: ['node'],
+    rsbuildConfig: {
+      root: fixtureRoot,
+      customLogger: createLogger({ level: 'silent' }),
+      output: { assetPrefix: 'https://cdn.example.com/app/' },
+      plugins: [pluginReactRouter({ lazyCompilation: false }), pluginReact()],
+    },
+  });
+
+  // `createCompiler` runs `onBeforeCreateCompiler`, where the prefix lookup
+  // happens.
+  const compiler = await rsbuild.createCompiler();
+  const names =
+    'compilers' in compiler
+      ? compiler.compilers.map(child => child.name)
+      : [compiler.name];
+  expect(names).toEqual(['node']);
+  expect(rsbuild.getNormalizedConfig().environments.web).toBeUndefined();
+}, 60_000);

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -360,11 +360,9 @@ describe('pluginReactRouter', () => {
       });
 
       rsbuild.addPlugins([pluginReactRouter()]);
-      const config = await rsbuild.unwrapConfig();
+      const nodeRspack = await rsbuild.unwrapRspackConfig('node');
 
-      expect(
-        config.environments?.node?.tools?.rspack?.output?.chunkFilename
-      ).toBe('static/js/async/[name].js');
+      expect(nodeRspack.output.chunkFilename).toBe('static/js/async/[name].js');
     });
 
     it('should emit package.json for node environment', async () => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -354,17 +354,6 @@ describe('pluginReactRouter', () => {
       ).toBe('../assets/styles-postcss-linked.[contenthash:10].css');
     });
 
-    it('routes server code-split chunks to static/js/async so they stay under the server build', async () => {
-      const rsbuild = await createStubRsbuild({
-        rsbuildConfig: {},
-      });
-
-      rsbuild.addPlugins([pluginReactRouter()]);
-      const nodeRspack = await rsbuild.unwrapRspackConfig('node');
-
-      expect(nodeRspack.output.chunkFilename).toBe('static/js/async/[name].js');
-    });
-
     it('should emit package.json for node environment', async () => {
       const rsbuild = await createStubRsbuild({
         rsbuildConfig: {},

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -436,14 +436,47 @@ describe('pluginReactRouter', () => {
     ]);
     expect(config.environments.node.tools.rspack.dependencies).toBeUndefined();
     expect(config.environments.web.output.target).toBe('web');
-    const webRspack = await rsbuild.unwrapRspackConfig('web');
-    expect(webRspack.output.workerChunkLoading).toBe('import-scripts');
     expect(
       config.environments.web.tools.rspack.optimization.usedExports
     ).toBeUndefined();
     expect(
       config.environments.web.tools.rspack.optimization.mangleExports
     ).toBeUndefined();
+  });
+
+  it('rejects web filename schemes the rspack RSC manifest would drop', async () => {
+    const rsbuild = await createStubRsbuild({
+      action: 'build',
+      rsbuildConfig: {
+        environments: {
+          web: { output: { filename: { js: '[name].js?v=[contenthash:8]' } } },
+        },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter({ rsc: true })]);
+
+    await expect(rsbuild.unwrapConfig()).rejects.toThrow(
+      /RSC mode requires web `output.filename.js` to end in "\.js"/
+    );
+  });
+
+  it('accepts hashed .js web filenames in RSC mode', async () => {
+    const rsbuild = await createStubRsbuild({
+      action: 'build',
+      rsbuildConfig: {
+        environments: {
+          web: { output: { filename: { js: '[contenthash:8]-[name].js' } } },
+        },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter({ rsc: true })]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.environments.web.output.filename.js).toBe(
+      '[contenthash:8]-[name].js'
+    );
   });
 
   it('shrinks classic production browser output', async () => {
@@ -459,12 +492,6 @@ describe('pluginReactRouter', () => {
       mangleExports: 'size',
       usedExports: 'global',
     });
-    // Async chunk names are Rsbuild's to derive from `output.filename` /
-    // `filenameHash` / `distPath.jsAsync`; the plugin sets none (#129).
-    const webRspack = await rsbuild.unwrapRspackConfig('web');
-    expect(webRspack.output.chunkFilename).toBeUndefined();
-    expect(webRspack.output.filename).toBeUndefined();
-    expect(webRspack.output.publicPath).toBeUndefined();
   });
 
   it('keeps classic development export names and chunk names', async () => {
@@ -481,8 +508,6 @@ describe('pluginReactRouter', () => {
     expect(
       config.environments.web.tools.rspack.optimization.usedExports
     ).toBeUndefined();
-    const webRspack = await rsbuild.unwrapRspackConfig('web');
-    expect(webRspack.output.chunkFilename).toBeUndefined();
   });
 
   // https://github.com/rstackjs/rsbuild-plugin-react-router/issues/129
@@ -502,9 +527,6 @@ describe('pluginReactRouter', () => {
     expect(config.environments.web.output.filename.js).toBe(
       '[name]-[contenthash:8].js'
     );
-    const webRspack = await rsbuild.unwrapRspackConfig('web');
-    expect(webRspack.output.filename).toBeUndefined();
-    expect(webRspack.output.chunkFilename).toBeUndefined();
   });
 
   it('leaves web output.filename.js to Rsbuild defaults when unset', async () => {
@@ -520,29 +542,6 @@ describe('pluginReactRouter', () => {
     expect(config.output?.filename?.js).toBeUndefined();
   });
 
-  it('lets user tools.rspack override plugin rspack output defaults', async () => {
-    const rsbuild = await createStubRsbuild({
-      action: 'build',
-      rsbuildConfig: {
-        environments: {
-          web: {
-            tools: {
-              rspack: (rspackConfig: any) => {
-                rspackConfig.output.chunkFilename = 'chunks/[name].js';
-              },
-            },
-          },
-        },
-      },
-    });
-
-    rsbuild.addPlugins([pluginReactRouter()]);
-    const webRspack = await rsbuild.unwrapRspackConfig('web');
-
-    expect(webRspack.output.chunkFilename).toBe('chunks/[name].js');
-    expect(webRspack.output.chunkFormat).toBe('module');
-  });
-
   // https://github.com/rstackjs/rsbuild-plugin-react-router/issues/130
   it('does not copy the asset prefix onto web output.publicPath', async () => {
     const rsbuild = await createStubRsbuild({
@@ -555,9 +554,12 @@ describe('pluginReactRouter', () => {
 
     rsbuild.addPlugins([pluginReactRouter()]);
     const config = await rsbuild.unwrapConfig();
-    const webRspack = await rsbuild.unwrapRspackConfig('web');
 
-    expect(webRspack.output.publicPath).toBeUndefined();
+    // Nothing in the merged web config pins a publicPath; the real-Rsbuild
+    // output test asserts the final compiler sees 'auto'.
+    expect(
+      config.environments.web.tools?.rspack?.output?.publicPath
+    ).toBeUndefined();
     expect(config.environments.web.output.assetPrefix).toBe('auto');
   });
 
@@ -1093,13 +1095,6 @@ describe('pluginReactRouter', () => {
     const nodeConfig = config.environments?.node?.tools?.rspack;
     expect(nodeConfig.externals).toContain('express');
     expect(nodeConfig.experiments.outputModule).toBe(true);
-    const nodeRspack = await rsbuild.unwrapRspackConfig('node');
-    expect(nodeRspack.output.devtoolModuleFilenameTemplate).toBe(
-      '[absolute-resource-path]'
-    );
-    expect(nodeRspack.output.devtoolFallbackModuleFilenameTemplate).toBe(
-      '[absolute-resource-path]?[hash]'
-    );
   });
 
   it('should apply the resolved development compiler dependency policy', async () => {
@@ -1163,25 +1158,4 @@ describe('pluginReactRouter', () => {
     expect(nodeConfig.target).toBe('async-node');
   });
 
-  it('applies federation chunk loading through modifyRspackConfig', async () => {
-    const rsbuild = await createStubRsbuild({ rsbuildConfig: {} });
-
-    rsbuild.addPlugins([
-      pluginReactRouter({ federation: true, serverOutput: 'commonjs' }),
-    ]);
-    const webRspack = await rsbuild.unwrapRspackConfig('web');
-    const nodeRspack = await rsbuild.unwrapRspackConfig('node');
-
-    // Remote containers are loaded as ES modules in the browser...
-    expect(webRspack.output.chunkLoading).toBe('import');
-    expect(webRspack.output.chunkFormat).toBe('module');
-    // ...and asynchronously on the CommonJS server. (The stub's base config
-    // plays a user `tools.rspack` that pins node `chunkLoading`, which must win
-    // over the hook, so assert the sibling the stub leaves alone.)
-    expect(nodeRspack.output.workerChunkLoading).toBe('async-node');
-    expect(nodeRspack.output.chunkFormat).toBe('commonjs');
-    // Filenames stay Rsbuild's: a federation remote names its container via
-    // ModuleFederationPlugin `filename`, not by the plugin forcing `[name].js`.
-    expect(webRspack.output.filename).toBeUndefined();
-  });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -5,11 +5,13 @@ import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { rspack } from '@rsbuild/core';
 import {
   pluginReactRouter,
   pluginReactRouterRSC,
   shouldParallelizeEnvironmentBuilds,
 } from '../src';
+import { getVirtualModuleFilePath } from '../src/virtual-modules';
 
 type ReactRouterTestGlobal = typeof globalThis & {
   __reactRouterTestConfig?: unknown;
@@ -457,10 +459,12 @@ describe('pluginReactRouter', () => {
       mangleExports: 'size',
       usedExports: 'global',
     });
+    // Async chunk names are Rsbuild's to derive from `output.filename` /
+    // `filenameHash` / `distPath.jsAsync`; the plugin sets none (#129).
     const webRspack = await rsbuild.unwrapRspackConfig('web');
-    expect(webRspack.output.chunkFilename).toBe(
-      'static/js/async/[id]-[contenthash:16].js'
-    );
+    expect(webRspack.output.chunkFilename).toBeUndefined();
+    expect(webRspack.output.filename).toBeUndefined();
+    expect(webRspack.output.publicPath).toBeUndefined();
   });
 
   it('keeps classic development export names and chunk names', async () => {
@@ -482,7 +486,7 @@ describe('pluginReactRouter', () => {
   });
 
   // https://github.com/rstackjs/rsbuild-plugin-react-router/issues/129
-  it('does not force web output.filename.js and yields chunkFilename to a user filename', async () => {
+  it('does not force web output.filename.js over a user filename', async () => {
     const rsbuild = await createStubRsbuild({
       action: 'build',
       rsbuildConfig: {
@@ -498,9 +502,8 @@ describe('pluginReactRouter', () => {
     expect(config.environments.web.output.filename.js).toBe(
       '[name]-[contenthash:8].js'
     );
-    // Rsbuild derives the async chunk name from `filename.js`; the plugin's
-    // `[id]-[contenthash:16]` default must not override the user's scheme.
     const webRspack = await rsbuild.unwrapRspackConfig('web');
+    expect(webRspack.output.filename).toBeUndefined();
     expect(webRspack.output.chunkFilename).toBeUndefined();
   });
 
@@ -556,6 +559,41 @@ describe('pluginReactRouter', () => {
 
     expect(webRspack.output.publicPath).toBeUndefined();
     expect(config.environments.web.output.assetPrefix).toBe('auto');
+  });
+
+  // Browser compiler on 'auto', server needs a usable absolute prefix: the
+  // root CDN prefix must survive rather than being folded into '/'.
+  it('falls back to the root asset prefix for server URLs when web is auto', async () => {
+    const rsbuild = await createStubRsbuild({
+      action: 'build',
+      rsbuildConfig: {
+        output: { assetPrefix: 'https://cdn.example.com/app/' },
+        environments: { web: { output: { assetPrefix: 'auto' } } },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+
+    const virtualModulePlugin = (config.tools?.rspack?.plugins || []).find(
+      (p: any) => p.constructor.name === 'VirtualModulesPlugin'
+    );
+    const compiler = {
+      context: '/virtual/project',
+      hooks: { afterEnvironment: { tap: (_n: string, h: () => void) => h() } },
+    } as any;
+    virtualModulePlugin.apply(compiler);
+    const serverBuildPath = join(
+      compiler.context,
+      getVirtualModuleFilePath('virtual/react-router/server-build')
+    );
+    const serverBuild = rspack.experiments.VirtualModulesPlugin.__internal__take_virtual_files(
+      compiler
+    )?.find(file => file.path === serverBuildPath);
+
+    expect(serverBuild?.content).toContain(
+      'export const publicPath = "https://cdn.example.com/app/";'
+    );
   });
 
   it('preserves production export names for RSC builds', async () => {
@@ -1123,5 +1161,27 @@ describe('pluginReactRouter', () => {
 
     const nodeConfig = config.environments?.node?.tools?.rspack;
     expect(nodeConfig.target).toBe('async-node');
+  });
+
+  it('applies federation chunk loading through modifyRspackConfig', async () => {
+    const rsbuild = await createStubRsbuild({ rsbuildConfig: {} });
+
+    rsbuild.addPlugins([
+      pluginReactRouter({ federation: true, serverOutput: 'commonjs' }),
+    ]);
+    const webRspack = await rsbuild.unwrapRspackConfig('web');
+    const nodeRspack = await rsbuild.unwrapRspackConfig('node');
+
+    // Remote containers are loaded as ES modules in the browser...
+    expect(webRspack.output.chunkLoading).toBe('import');
+    expect(webRspack.output.chunkFormat).toBe('module');
+    // ...and asynchronously on the CommonJS server. (The stub's base config
+    // plays a user `tools.rspack` that pins node `chunkLoading`, which must win
+    // over the hook, so assert the sibling the stub leaves alone.)
+    expect(nodeRspack.output.workerChunkLoading).toBe('async-node');
+    expect(nodeRspack.output.chunkFormat).toBe('commonjs');
+    // Filenames stay Rsbuild's: a federation remote names its container via
+    // ModuleFederationPlugin `filename`, not by the plugin forcing `[name].js`.
+    expect(webRspack.output.filename).toBeUndefined();
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -434,9 +434,8 @@ describe('pluginReactRouter', () => {
     ]);
     expect(config.environments.node.tools.rspack.dependencies).toBeUndefined();
     expect(config.environments.web.output.target).toBe('web');
-    expect(
-      config.environments.web.tools.rspack.output.workerChunkLoading
-    ).toBe('import-scripts');
+    const webRspack = await rsbuild.unwrapRspackConfig('web');
+    expect(webRspack.output.workerChunkLoading).toBe('import-scripts');
     expect(
       config.environments.web.tools.rspack.optimization.usedExports
     ).toBeUndefined();
@@ -458,7 +457,8 @@ describe('pluginReactRouter', () => {
       mangleExports: 'size',
       usedExports: 'global',
     });
-    expect(config.environments.web.tools.rspack.output.chunkFilename).toBe(
+    const webRspack = await rsbuild.unwrapRspackConfig('web');
+    expect(webRspack.output.chunkFilename).toBe(
       'static/js/async/[id]-[contenthash:16].js'
     );
   });
@@ -477,9 +477,85 @@ describe('pluginReactRouter', () => {
     expect(
       config.environments.web.tools.rspack.optimization.usedExports
     ).toBeUndefined();
-    expect(
-      config.environments.web.tools.rspack.output.chunkFilename
-    ).toBeUndefined();
+    const webRspack = await rsbuild.unwrapRspackConfig('web');
+    expect(webRspack.output.chunkFilename).toBeUndefined();
+  });
+
+  // https://github.com/rstackjs/rsbuild-plugin-react-router/issues/129
+  it('does not force web output.filename.js and yields chunkFilename to a user filename', async () => {
+    const rsbuild = await createStubRsbuild({
+      action: 'build',
+      rsbuildConfig: {
+        environments: {
+          web: { output: { filename: { js: '[name]-[contenthash:8].js' } } },
+        },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.environments.web.output.filename.js).toBe(
+      '[name]-[contenthash:8].js'
+    );
+    // Rsbuild derives the async chunk name from `filename.js`; the plugin's
+    // `[id]-[contenthash:16]` default must not override the user's scheme.
+    const webRspack = await rsbuild.unwrapRspackConfig('web');
+    expect(webRspack.output.chunkFilename).toBeUndefined();
+  });
+
+  it('leaves web output.filename.js to Rsbuild defaults when unset', async () => {
+    const rsbuild = await createStubRsbuild({
+      action: 'build',
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.environments.web.output?.filename?.js).toBeUndefined();
+    expect(config.output?.filename?.js).toBeUndefined();
+  });
+
+  it('lets user tools.rspack override plugin rspack output defaults', async () => {
+    const rsbuild = await createStubRsbuild({
+      action: 'build',
+      rsbuildConfig: {
+        environments: {
+          web: {
+            tools: {
+              rspack: (rspackConfig: any) => {
+                rspackConfig.output.chunkFilename = 'chunks/[name].js';
+              },
+            },
+          },
+        },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const webRspack = await rsbuild.unwrapRspackConfig('web');
+
+    expect(webRspack.output.chunkFilename).toBe('chunks/[name].js');
+    expect(webRspack.output.chunkFormat).toBe('module');
+  });
+
+  // https://github.com/rstackjs/rsbuild-plugin-react-router/issues/130
+  it('does not copy the asset prefix onto web output.publicPath', async () => {
+    const rsbuild = await createStubRsbuild({
+      action: 'build',
+      rsbuildConfig: {
+        output: { assetPrefix: '/' },
+        environments: { web: { output: { assetPrefix: 'auto' } } },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReactRouter()]);
+    const config = await rsbuild.unwrapConfig();
+    const webRspack = await rsbuild.unwrapRspackConfig('web');
+
+    expect(webRspack.output.publicPath).toBeUndefined();
+    expect(config.environments.web.output.assetPrefix).toBe('auto');
   });
 
   it('preserves production export names for RSC builds', async () => {
@@ -979,10 +1055,11 @@ describe('pluginReactRouter', () => {
     const nodeConfig = config.environments?.node?.tools?.rspack;
     expect(nodeConfig.externals).toContain('express');
     expect(nodeConfig.experiments.outputModule).toBe(true);
-    expect(nodeConfig.output.devtoolModuleFilenameTemplate).toBe(
+    const nodeRspack = await rsbuild.unwrapRspackConfig('node');
+    expect(nodeRspack.output.devtoolModuleFilenameTemplate).toBe(
       '[absolute-resource-path]'
     );
-    expect(nodeConfig.output.devtoolFallbackModuleFilenameTemplate).toBe(
+    expect(nodeRspack.output.devtoolFallbackModuleFilenameTemplate).toBe(
       '[absolute-resource-path]?[hash]'
     );
   });

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -114,6 +114,8 @@ describe('manifest', () => {
     expect(isManifestJsAsset('static/js/entry.client.js?v=abc12345')).toBe(true);
     expect(isManifestJsAsset('static/js/abc12345.js')).toBe(true);
     expect(isManifestJsAsset('static/js/abc12345-root.js')).toBe(true);
+    expect(isManifestJsAsset('static/js/routes/page.abc123.mjs')).toBe(true);
+    expect(isManifestJsAsset('static/js/routes/page.cjs?v=1')).toBe(true);
     expect(isManifestCssAsset('static/css/root.css?v=abc12345')).toBe(true);
     // HMR update files are recorded on `chunk.files` but are never the module.
     expect(isManifestJsAsset('static/js/root.abc12345.hot-update.js')).toBe(
@@ -608,6 +610,32 @@ describe('manifest', () => {
       expect(manifest.routes['routes/page'].module).toBe(
         '/static/js/0a1b2c3d-page.js'
       );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails the build instead of inventing a module path when a chunk has no script', async () => {
+    const { root, appDir } = createTempApp(`
+      export default function Page() { return null; }
+    `);
+    try {
+      const stats = {
+        assetsByChunkName: {
+          'entry.client': ['static/js/entry.client.js'],
+          root: ['static/js/root.js'],
+          // Metadata exists, but nothing the browser could import.
+          'routes/page': ['static/css/routes/page.css', 'static/js/routes/page.wasm'],
+        },
+      };
+
+      await expect(
+        generateReactRouterManifestForDev(routes, {}, stats, appDir, '/', {
+          isBuild: true,
+          rootRouteFile: 'root.tsx',
+          splitRouteModules: false,
+        })
+      ).rejects.toThrow(/Chunk "routes\/page" emitted no JavaScript asset/);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -107,6 +107,44 @@ describe('manifest', () => {
     });
   });
 
+  it('orders a content-hashed own chunk file first in manifest stats', () => {
+    const compilation = {
+      namedChunks: new Map([
+        [
+          'entry.client',
+          {
+            files: new Set([
+              'static/js/vendor.abc12345.js',
+              'static/js/entry.client.abc12345.js',
+            ]),
+          },
+        ],
+        [
+          'routes/page',
+          {
+            files: new Set([
+              'static/css/routes/page-abc12345.css',
+              'static/js/routes/page-abc12345.js',
+            ]),
+          },
+        ],
+      ]),
+    };
+
+    expect(createReactRouterManifestStats(compilation)).toEqual({
+      assetsByChunkName: {
+        'entry.client': [
+          'static/js/entry.client.abc12345.js',
+          'static/js/vendor.abc12345.js',
+        ],
+        'routes/page': [
+          'static/js/routes/page-abc12345.js',
+          'static/css/routes/page-abc12345.css',
+        ],
+      },
+    });
+  });
+
   it('skips missing named chunks while creating manifest stats', () => {
     const compilation = {
       namedChunks: new Map([

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -9,6 +9,8 @@ import {
   generateReactRouterManifestForDev,
   getReactRouterManifestForDev,
   getReactRouterManifestChunkNames,
+  isManifestCssAsset,
+  isManifestJsAsset,
 } from '../src/manifest';
 
 const createTempApp = (routeCode: string) => {
@@ -107,42 +109,18 @@ describe('manifest', () => {
     });
   });
 
-  it('orders a content-hashed own chunk file first in manifest stats', () => {
-    const compilation = {
-      namedChunks: new Map([
-        [
-          'entry.client',
-          {
-            files: new Set([
-              'static/js/vendor.abc12345.js',
-              'static/js/entry.client.abc12345.js',
-            ]),
-          },
-        ],
-        [
-          'routes/page',
-          {
-            files: new Set([
-              'static/css/routes/page-abc12345.css',
-              'static/js/routes/page-abc12345.js',
-            ]),
-          },
-        ],
-      ]),
-    };
-
-    expect(createReactRouterManifestStats(compilation)).toEqual({
-      assetsByChunkName: {
-        'entry.client': [
-          'static/js/entry.client.abc12345.js',
-          'static/js/vendor.abc12345.js',
-        ],
-        'routes/page': [
-          'static/js/routes/page-abc12345.js',
-          'static/css/routes/page-abc12345.css',
-        ],
-      },
-    });
+  it('classifies manifest assets by pathname regardless of filename scheme', () => {
+    // Query-hash filenames keep their query in the emitted reference.
+    expect(isManifestJsAsset('static/js/entry.client.js?v=abc12345')).toBe(true);
+    expect(isManifestJsAsset('static/js/abc12345.js')).toBe(true);
+    expect(isManifestJsAsset('static/js/abc12345-root.js')).toBe(true);
+    expect(isManifestCssAsset('static/css/root.css?v=abc12345')).toBe(true);
+    // HMR update files are recorded on `chunk.files` but are never the module.
+    expect(isManifestJsAsset('static/js/root.abc12345.hot-update.js')).toBe(
+      false
+    );
+    expect(isManifestJsAsset('static/js/root.js.map')).toBe(false);
+    expect(isManifestJsAsset('static/css/root.css')).toBe(false);
   });
 
   it('skips missing named chunks while creating manifest stats', () => {
@@ -577,6 +555,59 @@ describe('manifest', () => {
       expect(manifest.entry.module).toBe('/static/js/entry.client.js');
       expect(manifest.entry.imports).toEqual(['/static/js/shared.js']);
       expect(manifest.entry.imports).not.toContain(manifest.entry.module);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps user filename schemes (query hash, hash-first) as manifest module URLs', async () => {
+    const { root, appDir } = createTempApp(`
+      export default function Page() { return null; }
+    `);
+    try {
+      // `[name].js?v=[contenthash:8]` for the entry, `[contenthash:8]-[name].js`
+      // for routes: neither ends in `.js`-as-named, and neither may fall back
+      // to the assumed `static/js/<chunk>.js`.
+      const stats = {
+        assetsByChunkName: {
+          'entry.client': [
+            'static/js/entry.client.js?v=1a2b3c4d',
+            'static/js/entry.client.abc.hot-update.js',
+            'static/css/entry.client.css?v=1a2b3c4d',
+          ],
+          root: ['static/js/9f8e7d6c-root.js'],
+          'routes/page': ['static/js/0a1b2c3d-page.js'],
+        },
+        entrypointFilesByName: {
+          'entry.client': [
+            'static/js/runtime.js?v=deadbeef',
+            'static/js/entry.client.js?v=1a2b3c4d',
+          ],
+        },
+      };
+
+      const { manifest } = await generateReactRouterManifestForDev(
+        routes,
+        {},
+        stats,
+        appDir,
+        '/',
+        { isBuild: true, rootRouteFile: 'root.tsx', splitRouteModules: false }
+      );
+
+      expect(manifest.entry.module).toBe(
+        '/static/js/entry.client.js?v=1a2b3c4d'
+      );
+      expect(manifest.entry.imports).toEqual([
+        '/static/js/runtime.js?v=deadbeef',
+      ]);
+      expect(manifest.entry.css).toEqual([
+        '/static/css/entry.client.css?v=1a2b3c4d',
+      ]);
+      expect(manifest.routes.root.module).toBe('/static/js/9f8e7d6c-root.js');
+      expect(manifest.routes['routes/page'].module).toBe(
+        '/static/js/0a1b2c3d-page.js'
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/output-config.integration.test.ts
+++ b/tests/output-config.integration.test.ts
@@ -1,0 +1,163 @@
+import * as fs from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  createLogger,
+  createRsbuild,
+  type RsbuildConfig,
+  type RsbuildPlugin,
+  type Rspack,
+} from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { afterAll, beforeAll, describe, expect, it } from '@rstest/core';
+import { pluginReactRouter, pluginReactRouterRSC } from '../src';
+
+// Output precedence against real Rsbuild: `inspectConfig` runs the full
+// pipeline (config normalization, environment hooks, `modifyRspackConfig`,
+// then the user's `tools.rspack`) and returns the final Rspack configs, so
+// these assertions cannot be distorted by a simulated merge (#129, #130).
+
+const repositoryRoot = process.cwd();
+let fixtureRoot: string;
+
+beforeAll(() => {
+  const temporaryFixtures = join(repositoryRoot, 'tests/.tmp-dev-runtime');
+  mkdirSync(temporaryFixtures, { recursive: true });
+  fixtureRoot = mkdtempSync(join(temporaryFixtures, 'output-'));
+  cpSync(join(repositoryRoot, 'tests/fixtures/dev-runtime'), fixtureRoot, {
+    recursive: true,
+  });
+  (fs.existsSync as { mockRestore?: () => void }).mockRestore?.();
+  // The plugin resolves the app directory from the working directory.
+  process.chdir(fixtureRoot);
+});
+
+afterAll(() => {
+  process.chdir(repositoryRoot);
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+const inspect = async (
+  plugin: RsbuildPlugin,
+  rsbuildConfig: RsbuildConfig = {}
+): Promise<Record<string, Rspack.Configuration>> => {
+  const rsbuild = await createRsbuild({
+    cwd: fixtureRoot,
+    rsbuildConfig: {
+      root: fixtureRoot,
+      customLogger: createLogger({ level: 'silent' }),
+      ...rsbuildConfig,
+      plugins: [plugin, pluginReact(), ...(rsbuildConfig.plugins ?? [])],
+    },
+  });
+  const { origin } = await rsbuild.inspectConfig({ mode: 'production' });
+  return Object.fromEntries(
+    origin.bundlerConfigs.map(config => [config.name, config])
+  );
+};
+
+const output = (config: Rspack.Configuration) =>
+  config.output as NonNullable<Rspack.Configuration['output']>;
+
+describe('final Rspack output configuration (real Rsbuild)', () => {
+  it('leaves browser filenames and publicPath to Rsbuild in classic mode', async () => {
+    const { web, node } = await inspect(pluginReactRouter());
+
+    // Rsbuild's production defaults, not a plugin override.
+    expect(output(web).filename).toBe('static/js/[name].[contenthash:10].js');
+    expect(output(web).chunkFilename).toBe(
+      'static/js/async/[name].[contenthash:10].js'
+    );
+    expect(output(web).publicPath).toBe('/');
+    // Plugin defaults that classic mode needs.
+    expect(output(web)).toMatchObject({
+      chunkFormat: 'module',
+      chunkLoading: 'import',
+      module: true,
+      library: { type: 'module' },
+    });
+    // The server keeps deterministic filenames (React Router's server build
+    // file) and the plugin's chunk layout under the server build.
+    expect(output(node).filename).toBe('[name].js');
+    expect(output(node).chunkFilename).toBe('static/js/async/[name].js');
+    expect(output(node)).toMatchObject({
+      chunkFormat: 'module',
+      chunkLoading: 'import',
+      module: true,
+      library: { type: 'module' },
+      devtoolModuleFilenameTemplate: '[absolute-resource-path]',
+    });
+  });
+
+  it('honors a user web output.filename.js', async () => {
+    const { web } = await inspect(pluginReactRouter(), {
+      environments: {
+        web: { output: { filename: { js: '[contenthash:8]-[name].js' } } },
+      },
+    });
+
+    expect(output(web).filename).toBe('static/js/[contenthash:8]-[name].js');
+    expect(output(web).chunkFilename).toBe(
+      'static/js/async/[contenthash:8]-[name].js'
+    );
+  });
+
+  it('lets user tools.rspack (function form) override plugin output defaults', async () => {
+    const { web, node } = await inspect(pluginReactRouter(), {
+      environments: {
+        web: {
+          tools: {
+            rspack: config => {
+              config.output!.chunkFilename = 'chunks/[name].js';
+            },
+          },
+        },
+        node: {
+          tools: { rspack: { output: { chunkFilename: 'server-chunks/[name].js' } } },
+        },
+      },
+    });
+
+    expect(output(web).chunkFilename).toBe('chunks/[name].js');
+    expect(output(web).chunkFormat).toBe('module');
+    expect(output(node).chunkFilename).toBe('server-chunks/[name].js');
+  });
+
+  // https://github.com/rstackjs/rsbuild-plugin-react-router/issues/130
+  it("passes a web assetPrefix of 'auto' through to the browser compiler", async () => {
+    const { web } = await inspect(pluginReactRouter(), {
+      output: { assetPrefix: 'https://cdn.example.com/app/' },
+      environments: { web: { output: { assetPrefix: 'auto' } } },
+    });
+
+    expect(output(web).publicPath).toBe('auto');
+  });
+
+  it('configures CommonJS server output and federation chunk loading', async () => {
+    const { web, node } = await inspect(
+      pluginReactRouter({ serverOutput: 'commonjs', federation: true })
+    );
+
+    expect(output(web).chunkLoading).toBe('import');
+    expect(output(node)).toMatchObject({
+      chunkFormat: 'commonjs',
+      chunkLoading: 'async-node',
+      workerChunkLoading: 'async-node',
+      module: false,
+      library: { type: 'commonjs2' },
+    });
+    expect(node.target).toBe('async-node');
+  });
+
+  it('configures RSC browser output', async () => {
+    const { web } = await inspect(pluginReactRouterRSC());
+
+    expect(output(web)).toMatchObject({
+      chunkFormat: 'array-push',
+      chunkLoading: 'jsonp',
+      workerChunkLoading: 'import-scripts',
+      module: false,
+    });
+    expect(output(web).filename).toBe('static/js/[name].[contenthash:10].js');
+  });
+});

--- a/tests/plugin-utils.test.ts
+++ b/tests/plugin-utils.test.ts
@@ -169,6 +169,65 @@ describe('plugin-utils', () => {
         resolveEffectiveAssetPrefix({ dev: {}, output: {}, isBuild: false })
       ).toBe('/');
     });
+
+    // The web environment is the primary source; the root config is the
+    // fallback, consulted before 'auto' is normalized away (#130).
+    it('prefers the web environment prefix over the root prefix', () => {
+      expect(
+        resolveEffectiveAssetPrefix(
+          { output: { assetPrefix: 'https://cdn.example.com/' }, isBuild: true },
+          { output: { assetPrefix: '/root/' } }
+        )
+      ).toBe('https://cdn.example.com/');
+    });
+
+    it('falls back to the root prefix when the web prefix is auto', () => {
+      expect(
+        resolveEffectiveAssetPrefix(
+          { output: { assetPrefix: 'auto' }, isBuild: true },
+          { output: { assetPrefix: 'https://cdn.example.com/app' } }
+        )
+      ).toBe('https://cdn.example.com/app/');
+      expect(
+        resolveEffectiveAssetPrefix(
+          { output: { assetPrefix: 'auto' }, isBuild: true },
+          { output: { assetPrefix: '/app/' } }
+        )
+      ).toBe('/app/');
+    });
+
+    it('falls back to the root prefix when the web prefix is empty or unset', () => {
+      expect(
+        resolveEffectiveAssetPrefix(
+          { output: { assetPrefix: '' }, isBuild: true },
+          { output: { assetPrefix: '/app/' } }
+        )
+      ).toBe('/app/');
+      expect(
+        resolveEffectiveAssetPrefix(
+          { output: {}, isBuild: true },
+          { output: { assetPrefix: '/app/' } }
+        )
+      ).toBe('/app/');
+    });
+
+    it('resolves to root when web and root are both auto', () => {
+      expect(
+        resolveEffectiveAssetPrefix(
+          { output: { assetPrefix: 'auto' }, isBuild: true },
+          { output: { assetPrefix: 'auto' } }
+        )
+      ).toBe('/');
+    });
+
+    it('applies the fallback chain to dev.assetPrefix in dev mode', () => {
+      expect(
+        resolveEffectiveAssetPrefix(
+          { dev: { assetPrefix: 'auto' }, output: {}, isBuild: false },
+          { dev: { assetPrefix: '/dev-root/' }, output: { assetPrefix: '/cdn' } }
+        )
+      ).toBe('/dev-root/');
+    });
   });
 
   describe('transformRoute', () => {

--- a/tests/react-router-framework/integration/asset-prefix-auto-test.ts
+++ b/tests/react-router-framework/integration/asset-prefix-auto-test.ts
@@ -1,0 +1,235 @@
+import getPort from "get-port";
+import { test, expect, type Page } from "@playwright/test";
+
+import { css, js } from "./helpers/create-fixture.js";
+import {
+  build,
+  createProject,
+  customDev,
+  reactRouterConfig,
+} from "./helpers/rsbuild.js";
+
+// https://github.com/rstackjs/rsbuild-plugin-react-router/issues/130
+//
+// Two different responsibilities share the asset prefix:
+//
+//   - the server renders the *initial* asset URLs (scripts, manifest, entry
+//     CSS) before any browser runtime exists, so it needs an absolute prefix;
+//   - the browser runtime loads *async* JS and CSS. With
+//     `environments.web.output.assetPrefix: 'auto'` Rspack derives that base
+//     from the executing script's URL instead of a baked-in string.
+//
+// The plugin used to copy the (normalized) root prefix onto the web compiler's
+// `publicPath`, turning `'auto'` into `'/'`. ESM `import()` still resolved
+// against the script URL, but CssExtract builds async stylesheet URLs from
+// `__webpack_require__.p`, so async CSS was requested from the *page* origin.
+//
+// These tests serve HTML and assets from different places, make the page
+// origin return a real 404 for misplaced asset requests, and assert the async
+// stylesheet's request URL and the resulting computed style.
+
+const ASYNC_CSS_COLOR = "rgb(255, 0, 0)";
+
+const appFiles = {
+  "react-router.config.ts": reactRouterConfig({}),
+  "app/components/async-component.css": css`
+    .async-component {
+      color: ${ASYNC_CSS_COLOR};
+    }
+  `,
+  "app/components/async-component.tsx": js`
+    import "./async-component.css";
+    export default function AsyncComponent() {
+      return <p data-async className="async-component">async css</p>;
+    }
+  `,
+  "app/routes/_index.tsx": js`
+    import { lazy, Suspense, useState } from "react";
+    const AsyncComponent = lazy(() => import("../components/async-component"));
+
+    export default function Index() {
+      const [show, setShow] = useState(false);
+      return (
+        <>
+          <h1 data-home>Home</h1>
+          <button data-load onClick={() => setShow(true)}>load</button>
+          {show ? (
+            <Suspense fallback={<p data-fallback>loading</p>}>
+              <AsyncComponent />
+            </Suspense>
+          ) : null}
+        </>
+      );
+    }
+  `,
+  // Production server: the page origin serves the React Router app only. When
+  // ASSET_MOUNT is set, the built client is served under that path on the same
+  // origin (root subdirectory case); when CDN_PORT is set, a second origin
+  // serves it under CDN_MOUNT instead. Either way, `/static/*` on the page
+  // origin is unmatched and React Router answers with a real 404.
+  "server.mjs": js`
+    import { createRequestHandler } from "@react-router/express";
+    import express from "express";
+
+    const app = express();
+    if (process.env.ASSET_MOUNT) {
+      app.use(process.env.ASSET_MOUNT, express.static("build/client", { index: false }));
+    }
+    app.all("*", createRequestHandler({
+      build: await import("./build/server/static/js/app.js"),
+    }));
+    app.listen(Number(process.env.PORT), () => console.log("app on " + process.env.PORT));
+
+    if (process.env.CDN_PORT) {
+      const cdn = express();
+      cdn.use((_req, res, next) => {
+        res.setHeader("Access-Control-Allow-Origin", "*");
+        next();
+      });
+      cdn.use(process.env.CDN_MOUNT, express.static("build/client", { index: false }));
+      cdn.listen(Number(process.env.CDN_PORT), () => console.log("cdn on " + process.env.CDN_PORT));
+    }
+  `,
+};
+
+const rsbuildConfigFile = (rootAssetPrefix: string) => `
+  import { defineConfig } from "@rsbuild/core";
+  import { pluginReact } from "@rsbuild/plugin-react";
+  import { pluginReactRouter } from "rsbuild-plugin-react-router";
+
+  export default defineConfig({
+    plugins: [pluginReact(), pluginReactRouter({ customServer: true })],
+    // Server-rendered URLs (manifest, initial scripts/CSS) follow this prefix...
+    output: { assetPrefix: ${JSON.stringify(rootAssetPrefix)} },
+    // ...while the browser runtime derives its own base from the script URL.
+    environments: { web: { output: { assetPrefix: "auto" } } },
+  });
+`;
+
+type Case = {
+  name: string;
+  /** Resolve the root prefix and server env once ports are known. */
+  setup: (ports: { port: number; cdnPort: number }) => {
+    rootAssetPrefix: string;
+    env: Record<string, string>;
+    /** Origin + mount every asset request must start with. */
+    assetBase: string;
+  };
+};
+
+const cases: Case[] = [
+  {
+    name: "assets on a different origin (CDN) under a sub-path",
+    setup: ({ cdnPort }) => ({
+      rootAssetPrefix: `http://localhost:${cdnPort}/cdn/app/`,
+      env: { CDN_PORT: String(cdnPort), CDN_MOUNT: "/cdn/app" },
+      assetBase: `http://localhost:${cdnPort}/cdn/app/`,
+    }),
+  },
+  {
+    name: "assets on the page origin under a root subdirectory",
+    setup: ({ port }) => ({
+      rootAssetPrefix: "/app/",
+      env: { ASSET_MOUNT: "/app" },
+      assetBase: `http://localhost:${port}/app/`,
+    }),
+  },
+];
+
+async function collectAssetRequests(page: Page) {
+  const requests: string[] = [];
+  const failures: string[] = [];
+  page.on("request", (request) => {
+    if (/\.(?:m?js|css)(?:\?|$)/.test(request.url())) requests.push(request.url());
+  });
+  page.on("response", (response) => {
+    if (response.status() >= 400) failures.push(`${response.status()} ${response.url()}`);
+  });
+  const errors: Error[] = [];
+  page.on("pageerror", (error) => errors.push(error));
+  return { requests, failures, errors };
+}
+
+for (const testCase of cases) {
+  test.describe(`output.assetPrefix 'auto' on web: ${testCase.name}`, () => {
+    let port: number;
+    let cdnPort: number;
+    let assetBase: string;
+    let rootAssetPrefix: string;
+    let stop: () => Promise<void> | void;
+
+    test.beforeAll(async () => {
+      port = await getPort();
+      cdnPort = await getPort();
+      const resolved = testCase.setup({ port, cdnPort });
+      assetBase = resolved.assetBase;
+      rootAssetPrefix = resolved.rootAssetPrefix;
+      const cwd = await createProject({
+        ...appFiles,
+        "rsbuild.config.ts": rsbuildConfigFile(resolved.rootAssetPrefix),
+      });
+      const result = build({ cwd });
+      expect(result.stderr.toString()).toBe("");
+      expect(result.status).toBe(0);
+      stop = await customDev({
+        cwd,
+        port,
+        env: { NODE_ENV: "production", PORT: String(port), ...resolved.env },
+      });
+    });
+    test.afterAll(async () => {
+      await stop?.();
+    });
+
+    test("the page origin does not serve assets", async ({ request }) => {
+      const response = await request.get(
+        `http://localhost:${port}/static/js/definitely-missing.js`,
+      );
+      expect(response.status()).toBe(404);
+    });
+
+    test("server-rendered asset URLs use the root prefix", async ({ request }) => {
+      const response = await request.get(`http://localhost:${port}/`);
+      expect(response.status()).toBe(200);
+      const html = await response.text();
+      const urls = [...html.matchAll(/(?:src|href)="([^"]+\.(?:js|css)(?:\?[^"]*)?)"/g)].map(
+        (match) => match[1],
+      );
+      expect(urls.length).toBeGreaterThan(0);
+      // Exactly the configured root prefix (absolute CDN URL, or root-relative
+      // subdirectory), not the web compiler's 'auto' folded into '/'.
+      for (const url of urls) {
+        expect(url.startsWith(rootAssetPrefix), `initial asset URL ${url}`).toBe(true);
+      }
+      // The browser compiler kept 'auto': no `/static/...` root-relative URLs
+      // and no baked prefix inside the server-rendered document.
+      expect(html).not.toMatch(/(?:src|href)="\/static\//);
+    });
+
+    test("async CSS and JS load from the asset origin and apply", async ({ page }) => {
+      const { requests, failures, errors } = await collectAssetRequests(page);
+
+      await page.goto(`http://localhost:${port}/`, { waitUntil: "networkidle" });
+      await expect(page.locator("[data-home]")).toBeVisible();
+
+      const cssResponse = page.waitForResponse(
+        (response) => /\/static\/css\/async\//.test(response.url()),
+      );
+      await page.locator("[data-load]").click();
+      const asyncCss = await cssResponse;
+
+      // The defining #130 failure: async CSS requested from the page origin.
+      expect(asyncCss.url().startsWith(`${assetBase}static/css/async/`), asyncCss.url()).toBe(true);
+      expect(asyncCss.status()).toBe(200);
+      await expect(page.locator("[data-async]")).toHaveCSS("color", ASYNC_CSS_COLOR);
+
+      const asyncJs = requests.filter((url) => /\/static\/js\/async\//.test(url));
+      expect(asyncJs.length).toBeGreaterThan(0);
+      for (const url of requests) {
+        expect(url.startsWith(assetBase), `asset request ${url}`).toBe(true);
+      }
+      expect(failures).toEqual([]);
+      expect(errors).toEqual([]);
+    });
+  });
+}

--- a/tests/react-router-framework/integration/asset-prefix-auto-test.ts
+++ b/tests/react-router-framework/integration/asset-prefix-auto-test.ts
@@ -1,5 +1,8 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import getPort from "get-port";
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 import { css, js } from "./helpers/create-fixture.js";
 import {
@@ -8,25 +11,23 @@ import {
   customDev,
   reactRouterConfig,
 } from "./helpers/rsbuild.js";
+import { rsbuildBin } from "./helpers/rsbuild-adapter.js";
+import { observeAssetResponses } from "./helpers/asset-responses.js";
 
 // https://github.com/rstackjs/rsbuild-plugin-react-router/issues/130
 //
-// Two different responsibilities share the asset prefix:
+// Two responsibilities share the asset prefix: the server renders the *initial*
+// asset URLs before any browser runtime exists, and the browser runtime loads
+// *async* JS and CSS. With `environments.web.output.assetPrefix: 'auto'`
+// Rspack derives the runtime base from the executing script's URL. The plugin
+// used to copy the normalized root prefix onto the web compiler's `publicPath`,
+// so CssExtract requested async stylesheets from the page origin.
 //
-//   - the server renders the *initial* asset URLs (scripts, manifest, entry
-//     CSS) before any browser runtime exists, so it needs an absolute prefix;
-//   - the browser runtime loads *async* JS and CSS. With
-//     `environments.web.output.assetPrefix: 'auto'` Rspack derives that base
-//     from the executing script's URL instead of a baked-in string.
-//
-// The plugin used to copy the (normalized) root prefix onto the web compiler's
-// `publicPath`, turning `'auto'` into `'/'`. ESM `import()` still resolved
-// against the script URL, but CssExtract builds async stylesheet URLs from
-// `__webpack_require__.p`, so async CSS was requested from the *page* origin.
-//
-// These tests serve HTML and assets from different places, make the page
-// origin return a real 404 for misplaced asset requests, and assert the async
-// stylesheet's request URL and the resulting computed style.
+// Both scenarios serve assets only from a second origin and make the page
+// origin return a real 404 for an emitted asset. The relocation scenario is
+// the negative control: its build-time root prefix is `/`, so the old
+// hard-coded mechanism resolves async CSS to the page origin and fails, while
+// automatic resolution follows the script to the asset origin.
 
 const ASYNC_CSS_COLOR = "rgb(255, 0, 0)";
 
@@ -62,33 +63,56 @@ const appFiles = {
       );
     }
   `,
-  // Production server: the page origin serves the React Router app only. When
-  // ASSET_MOUNT is set, the built client is served under that path on the same
-  // origin (root subdirectory case); when CDN_PORT is set, a second origin
-  // serves it under CDN_MOUNT instead. Either way, `/static/*` on the page
-  // origin is unmatched and React Router answers with a real 404.
+  // Production server: the page origin serves the React Router app only, so
+  // `/static/*` there is unmatched and React Router answers with a real 404.
+  // A second origin serves the built client under CDN_MOUNT. With
+  // REWRITE_BASE set, the serving boundary rewrites root-relative asset URLs in
+  // the server-facing references (the HTML document and the browser manifest)
+  // to that base -- the compiled browser runtime is never touched.
   "server.mjs": js`
+    import { readFileSync } from "node:fs";
     import { createRequestHandler } from "@react-router/express";
     import express from "express";
 
+    const rewriteBase = process.env.REWRITE_BASE;
+    const rewrite = (text, quote) =>
+      rewriteBase ? text.replaceAll(quote + "/static/", quote + rewriteBase + "static/") : text;
+
     const app = express();
-    if (process.env.ASSET_MOUNT) {
-      app.use(process.env.ASSET_MOUNT, express.static("build/client", { index: false }));
+    if (rewriteBase) {
+      // Buffer HTML responses and rewrite their asset URLs at the boundary.
+      app.use((_req, res, next) => {
+        const chunks = [];
+        const end = res.end.bind(res);
+        res.write = (chunk) => (chunks.push(Buffer.from(chunk)), true);
+        res.end = (chunk) => {
+          if (chunk) chunks.push(Buffer.from(chunk));
+          let body = Buffer.concat(chunks).toString("utf8");
+          if (String(res.getHeader("content-type")).includes("text/html")) body = rewrite(body, '"');
+          res.removeHeader("content-length");
+          return end(body);
+        };
+        next();
+      });
     }
     app.all("*", createRequestHandler({
       build: await import("./build/server/static/js/app.js"),
     }));
     app.listen(Number(process.env.PORT), () => console.log("app on " + process.env.PORT));
 
-    if (process.env.CDN_PORT) {
-      const cdn = express();
-      cdn.use((_req, res, next) => {
-        res.setHeader("Access-Control-Allow-Origin", "*");
-        next();
+    const cdn = express();
+    cdn.use((_req, res, next) => {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      next();
+    });
+    if (rewriteBase) {
+      cdn.get(process.env.CDN_MOUNT + "/static/js/manifest-:version.js", (req, res) => {
+        res.type("application/javascript");
+        res.send(rewrite(readFileSync("build/client" + req.path.slice(process.env.CDN_MOUNT.length), "utf8"), "'"));
       });
-      cdn.use(process.env.CDN_MOUNT, express.static("build/client", { index: false }));
-      cdn.listen(Number(process.env.CDN_PORT), () => console.log("cdn on " + process.env.CDN_PORT));
     }
+    cdn.use(process.env.CDN_MOUNT, express.static("build/client", { index: false }));
+    cdn.listen(Number(process.env.CDN_PORT), () => console.log("cdn on " + process.env.CDN_PORT));
   `,
 };
 
@@ -106,67 +130,49 @@ const rsbuildConfigFile = (rootAssetPrefix: string) => `
   });
 `;
 
-type Case = {
+type Scenario = {
   name: string;
-  /** Resolve the root prefix and server env once ports are known. */
-  setup: (ports: { port: number; cdnPort: number }) => {
-    rootAssetPrefix: string;
-    env: Record<string, string>;
-    /** Origin + mount every asset request must start with. */
-    assetBase: string;
-  };
+  /** Root `output.assetPrefix` baked into the build. */
+  rootAssetPrefix: (cdnBase: string) => string;
+  /** Whether the document's initial URLs are rewritten at the serving boundary. */
+  relocate: boolean;
 };
 
-const cases: Case[] = [
+const scenarios: Scenario[] = [
   {
-    name: "assets on a different origin (CDN) under a sub-path",
-    setup: ({ cdnPort }) => ({
-      rootAssetPrefix: `http://localhost:${cdnPort}/cdn/app/`,
-      env: { CDN_PORT: String(cdnPort), CDN_MOUNT: "/cdn/app" },
-      assetBase: `http://localhost:${cdnPort}/cdn/app/`,
-    }),
+    name: "server falls back to the root CDN prefix while the browser stays on 'auto'",
+    rootAssetPrefix: (cdnBase) => cdnBase,
+    relocate: false,
   },
   {
-    name: "assets on the page origin under a root subdirectory",
-    setup: ({ port }) => ({
-      rootAssetPrefix: "/app/",
-      env: { ASSET_MOUNT: "/app" },
-      assetBase: `http://localhost:${port}/app/`,
-    }),
+    name: "relocated runtime: build-time root prefix '/' differs from where assets are served",
+    rootAssetPrefix: () => "/",
+    relocate: true,
   },
 ];
 
-async function collectAssetRequests(page: Page) {
-  const requests: string[] = [];
-  const failures: string[] = [];
-  page.on("request", (request) => {
-    if (/\.(?:m?js|css)(?:\?|$)/.test(request.url())) requests.push(request.url());
-  });
-  page.on("response", (response) => {
-    if (response.status() >= 400) failures.push(`${response.status()} ${response.url()}`);
-  });
-  const errors: Error[] = [];
-  page.on("pageerror", (error) => errors.push(error));
-  return { requests, failures, errors };
-}
+const listClientFiles = (cwd: string) =>
+  readdirSync(path.join(cwd, "build/client"), { recursive: true })
+    .map(String)
+    .map((file) => file.split(path.sep).join("/"));
 
-for (const testCase of cases) {
-  test.describe(`output.assetPrefix 'auto' on web: ${testCase.name}`, () => {
+for (const scenario of scenarios) {
+  test.describe(`web assetPrefix 'auto': ${scenario.name}`, () => {
+    let cwd: string;
     let port: number;
     let cdnPort: number;
-    let assetBase: string;
+    let cdnBase: string;
     let rootAssetPrefix: string;
     let stop: () => Promise<void> | void;
 
     test.beforeAll(async () => {
       port = await getPort();
       cdnPort = await getPort();
-      const resolved = testCase.setup({ port, cdnPort });
-      assetBase = resolved.assetBase;
-      rootAssetPrefix = resolved.rootAssetPrefix;
-      const cwd = await createProject({
+      cdnBase = `http://localhost:${cdnPort}/cdn/app/`;
+      rootAssetPrefix = scenario.rootAssetPrefix(cdnBase);
+      cwd = await createProject({
         ...appFiles,
-        "rsbuild.config.ts": rsbuildConfigFile(resolved.rootAssetPrefix),
+        "rsbuild.config.ts": rsbuildConfigFile(rootAssetPrefix),
       });
       const result = build({ cwd });
       expect(result.stderr.toString()).toBe("");
@@ -174,62 +180,80 @@ for (const testCase of cases) {
       stop = await customDev({
         cwd,
         port,
-        env: { NODE_ENV: "production", PORT: String(port), ...resolved.env },
+        env: {
+          NODE_ENV: "production",
+          PORT: String(port),
+          CDN_PORT: String(cdnPort),
+          CDN_MOUNT: "/cdn/app",
+          ...(scenario.relocate ? { REWRITE_BASE: cdnBase } : {}),
+        },
       });
     });
     test.afterAll(async () => {
       await stop?.();
     });
 
-    test("the page origin does not serve assets", async ({ request }) => {
-      const response = await request.get(
-        `http://localhost:${port}/static/js/definitely-missing.js`,
-      );
-      expect(response.status()).toBe(404);
-    });
+    test("async CSS and JS resolve from the loaded runtime's origin", async ({ page, request }) => {
+      const files = listClientFiles(cwd);
+      const emittedCss = files.find((file) => /^static\/css\/async\/.*\.css$/.test(file));
+      expect(emittedCss, "an async stylesheet was emitted").toBeDefined();
 
-    test("server-rendered asset URLs use the root prefix", async ({ request }) => {
-      const response = await request.get(`http://localhost:${port}/`);
-      expect(response.status()).toBe(200);
-      const html = await response.text();
-      const urls = [...html.matchAll(/(?:src|href)="([^"]+\.(?:js|css)(?:\?[^"]*)?)"/g)].map(
-        (match) => match[1],
-      );
-      expect(urls.length).toBeGreaterThan(0);
-      // Exactly the configured root prefix (absolute CDN URL, or root-relative
-      // subdirectory), not the web compiler's 'auto' folded into '/'.
-      for (const url of urls) {
-        expect(url.startsWith(rootAssetPrefix), `initial asset URL ${url}`).toBe(true);
-      }
-      // The browser compiler kept 'auto': no `/static/...` root-relative URLs
-      // and no baked prefix inside the server-rendered document.
-      expect(html).not.toMatch(/(?:src|href)="\/static\//);
-    });
+      await test.step("the final web compiler config keeps publicPath 'auto'", () => {
+        const inspect = spawnSync(process.argv[0], [rsbuildBin, "inspect", "--mode", "production"], {
+          cwd,
+          env: { ...process.env, NODE_ENV: "production" },
+        });
+        expect(inspect.status, inspect.stderr.toString()).toBe(0);
+        const webConfig = readFileSync(
+          path.join(cwd, "build/.rsbuild/rspack.config.web.mjs"),
+          "utf8",
+        );
+        // Complementary evidence only; the browser steps below are decisive.
+        expect.soft(webConfig).toMatch(/publicPath: 'auto'/);
+      });
 
-    test("async CSS and JS load from the asset origin and apply", async ({ page }) => {
-      const { requests, failures, errors } = await collectAssetRequests(page);
+      await test.step("the page origin cannot serve an emitted asset", async () => {
+        const wrongOrigin = await request.get(`http://localhost:${port}/${emittedCss}`);
+        expect(wrongOrigin.status()).toBe(404);
+        const rightOrigin = await request.get(`${cdnBase}${emittedCss}`);
+        expect(rightOrigin.status()).toBe(200);
+      });
 
+      const observed = observeAssetResponses(page);
       await page.goto(`http://localhost:${port}/`, { waitUntil: "networkidle" });
       await expect(page.locator("[data-home]")).toBeVisible();
 
-      const cssResponse = page.waitForResponse(
-        (response) => /\/static\/css\/async\//.test(response.url()),
-      );
-      await page.locator("[data-load]").click();
-      const asyncCss = await cssResponse;
+      await test.step("server-rendered initial asset URLs use the root prefix", async () => {
+        const initial = await page.evaluate(() =>
+          [...document.querySelectorAll("script[src], link[href]")].map(
+            (el) => el.getAttribute("src") ?? el.getAttribute("href") ?? "",
+          ),
+        );
+        expect(initial.length).toBeGreaterThan(0);
+        for (const url of initial) {
+          const expected = scenario.relocate ? cdnBase : rootAssetPrefix;
+          expect(url.startsWith(expected), `initial URL ${url}`).toBe(true);
+        }
+      });
 
-      // The defining #130 failure: async CSS requested from the page origin.
-      expect(asyncCss.url().startsWith(`${assetBase}static/css/async/`), asyncCss.url()).toBe(true);
-      expect(asyncCss.status()).toBe(200);
-      await expect(page.locator("[data-async]")).toHaveCSS("color", ASYNC_CSS_COLOR);
+      await test.step("the browser runtime loads async JS and CSS from the asset origin", async () => {
+        const cssResponse = page.waitForResponse((response) =>
+          /\/static\/css\/async\//.test(response.url()),
+        );
+        await page.locator("[data-load]").click();
+        const asyncCss = await cssResponse;
+        // The defining #130 failure: async CSS requested from the page origin.
+        expect(asyncCss.url().startsWith(`${cdnBase}static/css/async/`), asyncCss.url()).toBe(true);
+        expect(asyncCss.status()).toBe(200);
+        await expect(page.locator("[data-async]")).toHaveCSS("color", ASYNC_CSS_COLOR);
 
-      const asyncJs = requests.filter((url) => /\/static\/js\/async\//.test(url));
-      expect(asyncJs.length).toBeGreaterThan(0);
-      for (const url of requests) {
-        expect(url.startsWith(assetBase), `asset request ${url}`).toBe(true);
-      }
-      expect(failures).toEqual([]);
-      expect(errors).toEqual([]);
+        expect(observed.requests.some((url) => /\/static\/js\/async\//.test(url))).toBe(true);
+        for (const url of observed.requests) {
+          expect(url.startsWith(cdnBase), `asset request ${url}`).toBe(true);
+        }
+        expect(observed.failures).toEqual([]);
+        expect(observed.pageErrors).toEqual([]);
+      });
     });
   });
 }

--- a/tests/react-router-framework/integration/federation-test.ts
+++ b/tests/react-router-framework/integration/federation-test.ts
@@ -1,0 +1,308 @@
+import getPort from "get-port";
+import { test, expect } from "@playwright/test";
+
+import { css, js } from "./helpers/create-fixture.js";
+import {
+  build,
+  createProject,
+  customDev,
+  reactRouterConfig,
+} from "./helpers/rsbuild.js";
+import { observeAssetResponses } from "./helpers/asset-responses.js";
+
+// Module Federation with `federation: true`, a minimal host and remote.
+//
+// The remote is BUILT with root `output.assetPrefix` pointing at origin A
+// (`/remote/v1/`) and the browser compiler on `'auto'`. The host's browser
+// loads the container from origin B under a different sub-path (`/remote/v2/`).
+// Origin A serves the same client build but refuses async stylesheets, so a
+// browser runtime that had the build-time prefix baked in (the plugin's old
+// forced `publicPath`) fails the lazy import's CSS, whereas automatic
+// resolution follows the loaded runtime to B.
+//
+// Covered: direct ESM container on another origin + sub-path; an exposed
+// component with a further lazy JS/CSS dependency; relocated automatic browser
+// runtime with a negative control; CORS on the remote's asset responses.
+// Not covered here: a Node federation consumer (the CommonJS `asyncStartup`
+// server build currently resolves to `undefined` with @module-federation/node
+// 2.7.44, independent of this plugin's output changes) and manifest-based
+// (`mf-manifest.json`) remote loading.
+
+const DETAILS_COLOR = "rgb(0, 0, 255)";
+
+const SHARED = `{
+  react: { singleton: true },
+  "react/": { singleton: true },
+  "react-dom": { singleton: true },
+  "react-dom/": { singleton: true },
+  "react-router": { singleton: true },
+  "react-router/": { singleton: true },
+}`;
+
+const remoteFiles = (rootAssetPrefix: string) => ({
+  "react-router.config.ts": reactRouterConfig({}),
+  "rsbuild.config.ts": `
+    import { ModuleFederationPlugin } from "@module-federation/enhanced/rspack";
+    import { defineConfig } from "@rsbuild/core";
+    import { pluginReact } from "@rsbuild/plugin-react";
+    import { pluginReactRouter } from "rsbuild-plugin-react-router";
+
+    const common = {
+      name: "remote",
+      exposes: { "./Widget": "./app/federation/widget.tsx" },
+      shared: ${SHARED},
+      shareStrategy: "loaded-first",
+      experiments: { asyncStartup: true },
+      dts: false,
+      // Stable container URLs; every other chunk keeps Rsbuild's content hash.
+      filename: "static/js/remote.js",
+    };
+
+    export default defineConfig({
+      plugins: [
+        pluginReactRouter({ customServer: true, serverOutput: "commonjs", federation: true }),
+        pluginReact({ splitChunks: { react: false, router: false } }),
+      ],
+      // Server-rendered URLs and the Node federation chunk base.
+      output: { assetPrefix: ${JSON.stringify(rootAssetPrefix)} },
+      environments: {
+        web: {
+          // The browser runtime follows the script it was loaded from.
+          output: { assetPrefix: "auto" },
+          tools: { rspack: { plugins: [new ModuleFederationPlugin({ ...common, library: { type: "module" } })] } },
+        },
+        node: {
+          tools: { rspack: { plugins: [new ModuleFederationPlugin({
+            ...common,
+            library: { type: "commonjs-module" },
+            runtimePlugins: ["@module-federation/node/runtimePlugin"],
+          })] } },
+        },
+      },
+    });
+  `,
+  "app/federation/widget-details.css": css`
+    .widget-details {
+      color: ${DETAILS_COLOR};
+    }
+  `,
+  "app/federation/widget-details.tsx": js`
+    import "./widget-details.css";
+    export default function WidgetDetails() {
+      return <p data-widget-details className="widget-details">remote details</p>;
+    }
+  `,
+  "app/federation/widget.tsx": js`
+    import { lazy, Suspense, useState } from "react";
+    const Details = lazy(() => import("./widget-details"));
+    export default function Widget() {
+      const [open, setOpen] = useState(false);
+      return (
+        <div data-widget>
+          <span data-widget-label>remote widget</span>
+          <button data-widget-open onClick={() => setOpen(true)}>open</button>
+          {open ? <Suspense fallback={<p data-widget-loading>loading</p>}><Details /></Suspense> : null}
+        </div>
+      );
+    }
+  `,
+  "app/routes/_index.tsx": js`
+    export default function Index() {
+      return <h1>remote</h1>;
+    }
+  `,
+  // Origin A (SERVER_MOUNT, the build-time root prefix): the client build minus
+  // async stylesheets. Origin B (CLIENT_MOUNT): the full client build, where
+  // the host actually loads the container from.
+  "server.mjs": js`
+    import express from "express";
+
+    const cors = (_req, res, next) => {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      next();
+    };
+
+    const a = express();
+    a.use(cors);
+    a.get("/", (_req, res) => res.end("remote"));
+    a.use(process.env.SERVER_MOUNT + "/static/css/async", (_req, res) => res.status(404).end("blocked"));
+    a.use(process.env.SERVER_MOUNT, express.static("build/client", { index: false }));
+    a.listen(Number(process.env.PORT), () => console.log("remote A on " + process.env.PORT));
+
+    const b = express();
+    b.use(cors);
+    b.use(process.env.CLIENT_MOUNT, express.static("build/client", { index: false }));
+    b.listen(Number(process.env.CLIENT_PORT), () => console.log("remote B on " + process.env.CLIENT_PORT));
+  `,
+});
+
+const hostFiles = (remoteWebEntry: string) => ({
+  "react-router.config.ts": reactRouterConfig({}),
+  "rsbuild.config.ts": `
+    import { ModuleFederationPlugin } from "@module-federation/enhanced/rspack";
+    import { defineConfig } from "@rsbuild/core";
+    import { pluginReact } from "@rsbuild/plugin-react";
+    import { pluginReactRouter } from "rsbuild-plugin-react-router";
+
+    export default defineConfig({
+      plugins: [
+        pluginReactRouter({ customServer: true, serverOutput: "commonjs", federation: true }),
+        pluginReact({ splitChunks: { react: false, router: false } }),
+      ],
+      environments: {
+        web: {
+          tools: { rspack: { plugins: [new ModuleFederationPlugin({
+            name: "host",
+            shared: ${SHARED},
+            shareStrategy: "loaded-first",
+            experiments: { asyncStartup: true },
+            dts: false,
+            remoteType: "import",
+            remotes: { remote: ${JSON.stringify(remoteWebEntry)} },
+          })] } },
+        },
+        // The remote is consumed in the browser only; keep the specifier out
+        // of the server bundle.
+        node: { output: { externals: ["remote/Widget"] } },
+      },
+    });
+  `,
+  "app/routes/_index.tsx": js`
+    import { lazy, Suspense, useEffect, useState } from "react";
+    const Widget = lazy(() => import("remote/Widget"));
+
+    export default function Index() {
+      const [mounted, setMounted] = useState(false);
+      useEffect(() => setMounted(true), []);
+      return (
+        <>
+          <h1 data-host>host</h1>
+          {mounted ? <Suspense fallback={<p data-widget-pending>loading remote</p>}><Widget /></Suspense> : null}
+        </>
+      );
+    }
+  `,
+  "server.mjs": js`
+    import { createRequestHandler } from "@react-router/express";
+    import express from "express";
+    import { resolveReactRouterServerBuild } from "rsbuild-plugin-react-router";
+
+    // CommonJS + federation async startup: the server build resolves asynchronously.
+    const build = await resolveReactRouterServerBuild(
+      await import("./build/server/static/js/app.js"),
+    );
+    const app = express();
+    app.use(express.static("build/client", { index: false }));
+    app.all("*", createRequestHandler({ build }));
+    app.listen(Number(process.env.PORT), () => console.log("host on " + process.env.PORT));
+  `,
+});
+
+test.describe("Module Federation: remote consumed by a host on other origins", () => {
+  // Pre-existing (reproduces identically with the plugin built from `main`):
+  // in production, the host's browser entry never reaches hydration once
+  // `federation: true` forces MF `experiments.asyncStartup` (no React fibers
+  // attach, the remote container is never requested, no console errors), and a
+  // Node consumer's CommonJS async server build resolves to `undefined`. The
+  // Epic Stack federation host fails to boot on `main` for the same reasons.
+  // Keep this fixture as the reproduction; lift the fixme once the plugin's
+  // federation startup integration is fixed.
+  test.fixme(
+    true,
+    "federation: true production startup never hydrates the host (pre-existing; see comment)",
+  );
+
+  let hostPort: number;
+  let remoteAPort: number;
+  let remoteBPort: number;
+  let remoteABase: string;
+  let remoteBBase: string;
+  const stops: Array<() => Promise<void> | void> = [];
+
+  test.beforeAll(async () => {
+    hostPort = await getPort();
+    remoteAPort = await getPort();
+    remoteBPort = await getPort();
+    remoteABase = `http://localhost:${remoteAPort}/remote/v1/`;
+    remoteBBase = `http://localhost:${remoteBPort}/remote/v2/`;
+
+    const remoteCwd = await createProject(remoteFiles(remoteABase));
+    const remoteBuild = build({ cwd: remoteCwd });
+    expect(remoteBuild.status, remoteBuild.stderr.toString()).toBe(0);
+    stops.push(
+      await customDev({
+        cwd: remoteCwd,
+        port: remoteAPort,
+        env: {
+          NODE_ENV: "production",
+          PORT: String(remoteAPort),
+          SERVER_MOUNT: "/remote/v1",
+          CLIENT_PORT: String(remoteBPort),
+          CLIENT_MOUNT: "/remote/v2",
+        },
+      }),
+    );
+
+    // Separate project directory: the host cannot read the remote build.
+    const hostCwd = await createProject(hostFiles(`${remoteBBase}static/js/remote.js`));
+    const hostBuild = build({ cwd: hostCwd });
+    expect(hostBuild.status, hostBuild.stderr.toString()).toBe(0);
+    stops.push(
+      await customDev({
+        cwd: hostCwd,
+        port: hostPort,
+        env: { NODE_ENV: "production", PORT: String(hostPort) },
+      }),
+    );
+  });
+  test.afterAll(async () => {
+    for (const stop of stops.reverse()) await stop();
+  });
+
+  test("loads a remote component and its lazy JS/CSS from the origin the container came from", async ({
+    page,
+    request,
+  }) => {
+    await test.step("remote asset responses carry CORS for the module graph", async () => {
+      for (const url of [`${remoteBBase}static/js/remote.js`, `${remoteBBase}mf-manifest.json`]) {
+        const response = await request.get(url);
+        expect(response.status(), url).toBe(200);
+        expect(response.headers()["access-control-allow-origin"], url).toBe("*");
+      }
+    });
+
+    await test.step("origin A (the build-time prefix) refuses the remote's async stylesheets", async () => {
+      const blocked = await request.get(`${remoteABase}static/css/async/any.css`);
+      expect(blocked.status()).toBe(404);
+    });
+
+    const observed = observeAssetResponses(page);
+    await page.goto(`http://localhost:${hostPort}/`, { waitUntil: "networkidle" });
+    await expect(page.locator("[data-widget-label]")).toHaveText("remote widget");
+
+    await test.step("the browser loaded the container from origin B", () => {
+      expect(observed.requests).toContain(`${remoteBBase}static/js/remote.js`);
+    });
+
+    await test.step("the exposed component's lazy JS and CSS resolve from the loaded runtime (origin B)", async () => {
+      const cssResponse = page.waitForResponse((response) =>
+        /\/static\/css\/async\//.test(response.url()),
+      );
+      await page.locator("[data-widget-open]").click();
+      const asyncCss = await cssResponse;
+      expect(asyncCss.url().startsWith(`${remoteBBase}static/css/async/`), asyncCss.url()).toBe(true);
+      expect(asyncCss.status()).toBe(200);
+      await expect(page.locator("[data-widget-details]")).toHaveCSS("color", DETAILS_COLOR);
+
+      // Remote-owned assets come from the remote; shared singletons are the
+      // host's, so only remote URLs are constrained here.
+      const remoteOwned = observed.requests.filter((url) => url.includes("/remote/"));
+      expect(remoteOwned.some((url) => /\/static\/js\/async\//.test(url))).toBe(true);
+      for (const url of remoteOwned) {
+        expect(url.startsWith(remoteBBase), `remote asset ${url}`).toBe(true);
+      }
+      expect(observed.failures).toEqual([]);
+      expect(observed.pageErrors).toEqual([]);
+    });
+  });
+});

--- a/tests/react-router-framework/integration/helpers/asset-responses.ts
+++ b/tests/react-router-framework/integration/helpers/asset-responses.ts
@@ -1,0 +1,43 @@
+import type { Page } from "@playwright/test";
+
+export type ObservedAssetResponses = {
+  /** Script/stylesheet request URLs, in request order. */
+  requests: string[];
+  /** Final response per script/stylesheet URL. */
+  responses: Map<string, { status: number; contentType: string }>;
+  /** HTTP >= 400 responses and network-level request failures. */
+  failures: string[];
+  pageErrors: Error[];
+};
+
+const ASSET_URL = /\.(?:m?js|css)(?:\?|$)/;
+
+// Records what the browser actually fetched for scripts and stylesheets, so
+// regression tests assert on real runtime requests instead of replaying HTTP.
+export const observeAssetResponses = (page: Page): ObservedAssetResponses => {
+  const observed: ObservedAssetResponses = {
+    requests: [],
+    responses: new Map(),
+    failures: [],
+    pageErrors: [],
+  };
+  page.on("request", (request) => {
+    if (ASSET_URL.test(request.url())) observed.requests.push(request.url());
+  });
+  page.on("requestfailed", (request) => {
+    observed.failures.push(`${request.failure()?.errorText ?? "failed"} ${request.url()}`);
+  });
+  page.on("response", (response) => {
+    if (ASSET_URL.test(response.url())) {
+      observed.responses.set(response.url(), {
+        status: response.status(),
+        contentType: response.headers()["content-type"] ?? "",
+      });
+    }
+    if (response.status() >= 400) {
+      observed.failures.push(`${response.status()} ${response.url()}`);
+    }
+  });
+  page.on("pageerror", (error) => observed.pageErrors.push(error));
+  return observed;
+};

--- a/tests/react-router-framework/integration/helpers/rsbuild-template/package.json
+++ b/tests/react-router-framework/integration/helpers/rsbuild-template/package.json
@@ -25,6 +25,8 @@
   },
   "devDependencies": {
     "@mdx-js/rollup": "^3.1.1",
+    "@module-federation/enhanced": "2.5.1",
+    "@module-federation/node": "2.7.44",
     "@react-router/dev": "^8.3.1",
     "@react-router/fs-routes": "^8.3.1",
     "@react-router/remix-routes-option-adapter": "^8.3.1",

--- a/tests/react-router-framework/integration/output-filename-test.ts
+++ b/tests/react-router-framework/integration/output-filename-test.ts
@@ -1,7 +1,7 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import path from "node:path";
 import getPort from "get-port";
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 import { js } from "./helpers/create-fixture.js";
 import {
@@ -11,6 +11,7 @@ import {
   reactRouterServe,
   rsbuildConfig,
 } from "./helpers/rsbuild.js";
+import { observeAssetResponses } from "./helpers/asset-responses.js";
 
 // https://github.com/rstackjs/rsbuild-plugin-react-router/issues/129
 //
@@ -139,53 +140,10 @@ const appFiles = {
   `,
 };
 
-const listClientFiles = (cwd: string) =>
-  readdirSync(path.join(cwd, "build/client"), { recursive: true })
-    .map(String)
-    .map((file) => file.split(path.sep).join("/"));
-
-const readManifest = (cwd: string, files: string[]) => {
-  const manifestFile = files.find((file) =>
-    /^static\/js\/(?:[^/]+\/)*manifest-[a-f0-9]+\.js$/.test(file),
-  );
-  expect(manifestFile, "browser manifest asset").toBeDefined();
-  const source = readFileSync(
-    path.join(cwd, "build/client", manifestFile!),
-    "utf8",
-  );
-  // `window.__reactRouterManifest={...};` serialized with jsesc (single quotes).
-  const json = source
-    .replace(/^window\.__reactRouterManifest=/, "")
-    .replace(/;$/, "");
-  return new Function(`return (${json});`)() as {
-    entry: { module: string; imports: string[] };
-    routes: Record<string, { module: string; imports?: string[] }>;
-  };
+type BrowserManifest = {
+  entry: { module: string; imports: string[] };
+  routes: Record<string, { module: string }>;
 };
-
-async function exerciseRoute(page: Page, port: number) {
-  const pageErrors: Error[] = [];
-  page.on("pageerror", (error) => pageErrors.push(error));
-  const failed: string[] = [];
-  page.on("response", (response) => {
-    if (response.status() >= 400) failed.push(`${response.status()} ${response.url()}`);
-  });
-
-  await page.goto(`http://localhost:${port}/`, { waitUntil: "networkidle" });
-  await expect(page.locator("[data-home]")).toBeVisible();
-
-  // Client-side navigation loads routes/page from the manifest `module` URL;
-  // the clientLoader only exists in that module.
-  await page.locator("[data-link]").click();
-  await expect(page.locator("[data-source]")).toHaveText("clientLoader");
-  // Hydrated interactivity + async chunk through the browser publicPath.
-  await page.locator("[data-inc]").click();
-  await expect(page.locator("[data-inc]")).toHaveText("1");
-  await expect(page.locator("[data-lazy]")).toHaveText("lazy chunk loaded");
-
-  expect(failed).toEqual([]);
-  expect(pageErrors).toEqual([]);
-}
 
 for (const scheme of schemes) {
   test.describe(`Browser output filenames: ${scheme.name}`, () => {
@@ -218,35 +176,61 @@ for (const scheme of schemes) {
       await stop?.();
     });
 
-    test("emits files with the configured scheme and the manifest references them", async () => {
-      const files = listClientFiles(cwd);
-      expect(files.filter((f) => scheme.entryFile.test(f))).toHaveLength(1);
-      expect(files.filter((f) => scheme.routeFile.test(f))).toHaveLength(1);
-      expect(files.filter((f) => scheme.asyncFile.test(f)).length).toBeGreaterThan(0);
+    test("emits, references, and executes modules under the configured scheme", async ({
+      page,
+    }) => {
+      const files = readdirSync(path.join(cwd, "build/client"), { recursive: true })
+        .map(String)
+        .map((file) => file.split(path.sep).join("/"));
+      const observed = observeAssetResponses(page);
 
-      const manifest = readManifest(cwd, files);
-      expect(manifest.routes["routes/page"].module).toMatch(scheme.routeModuleUrl);
-      // The entry module URL must be the emitted entry file (plus any query).
-      const entryUrl = manifest.entry.module.split("?")[0].replace(/^\//, "");
-      expect(files).toContain(entryUrl);
-      expect(manifest.entry.imports).not.toContain(manifest.entry.module);
-    });
+      await test.step("emitted files follow the scheme", () => {
+        expect(files.filter((f) => scheme.entryFile.test(f))).toHaveLength(1);
+        expect(files.filter((f) => scheme.routeFile.test(f))).toHaveLength(1);
+        expect(files.filter((f) => scheme.asyncFile.test(f)).length).toBeGreaterThan(0);
+      });
 
-    test("manifest URLs resolve to the emitted JavaScript", async ({ request }) => {
-      const manifest = readManifest(cwd, listClientFiles(cwd));
-      for (const url of [
-        manifest.entry.module,
-        ...manifest.entry.imports,
-        manifest.routes["routes/page"].module,
-      ]) {
-        const response = await request.get(`http://localhost:${port}${url}`);
-        expect(response.status(), url).toBe(200);
-        expect(response.headers()["content-type"], url).toMatch(/javascript/);
-      }
-    });
+      await page.goto(`http://localhost:${port}/`, { waitUntil: "networkidle" });
+      await expect(page.locator("[data-home]")).toBeVisible();
 
-    test("routes hydrate and navigate through the manifest modules", async ({ page }) => {
-      await exerciseRoute(page, port);
+      const manifest = await test.step("browser manifest references the emitted files", async () => {
+        const manifest = await page.evaluate(
+          () => (window as unknown as { __reactRouterManifest: BrowserManifest }).__reactRouterManifest,
+        );
+        expect(manifest.routes["routes/page"].module).toMatch(scheme.routeModuleUrl);
+        const entryPath = manifest.entry.module.split("?")[0].replace(/^\//, "");
+        expect(files).toContain(entryPath);
+        expect(manifest.entry.imports).not.toContain(manifest.entry.module);
+        return manifest;
+      });
+
+      await test.step("client navigation runs the route module's clientLoader", async () => {
+        // The clientLoader only exists in the manifest-resolved routes/page
+        // module; a manifest pointing at the wrong existing file fails here.
+        await page.locator("[data-link]").click();
+        await expect(page.locator("[data-source]")).toHaveText("clientLoader");
+      });
+
+      await test.step("hydration and the lazy import work", async () => {
+        await page.locator("[data-inc]").click();
+        await expect(page.locator("[data-inc]")).toHaveText("1");
+        await expect(page.locator("[data-lazy]")).toHaveText("lazy chunk loaded");
+      });
+
+      await test.step("the browser fetched each manifest URL as JavaScript", () => {
+        for (const url of [
+          manifest.entry.module,
+          ...manifest.entry.imports,
+          manifest.routes["routes/page"].module,
+        ]) {
+          const response = observed.responses.get(`http://localhost:${port}${url}`);
+          expect(response, `response for ${url}`).toBeDefined();
+          expect(response!.status, url).toBe(200);
+          expect(response!.contentType, url).toMatch(/javascript/);
+        }
+        expect(observed.failures).toEqual([]);
+        expect(observed.pageErrors).toEqual([]);
+      });
     });
   });
 }

--- a/tests/react-router-framework/integration/output-filename-test.ts
+++ b/tests/react-router-framework/integration/output-filename-test.ts
@@ -1,0 +1,252 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import getPort from "get-port";
+import { test, expect, type Page } from "@playwright/test";
+
+import { js } from "./helpers/create-fixture.js";
+import {
+  build,
+  createProject,
+  reactRouterConfig,
+  reactRouterServe,
+  rsbuildConfig,
+} from "./helpers/rsbuild.js";
+
+// https://github.com/rstackjs/rsbuild-plugin-react-router/issues/129
+//
+// The plugin must not dictate browser JavaScript filenames: Rsbuild's
+// production default, `output.filenameHash: false`, a custom string or function
+// `output.filename.js`, a query-hash filename, and a `tools.rspack`
+// `chunkFilename` override must all (a) be emitted as configured and (b) be
+// what the browser manifest points at. A manifest that references an existing
+// but *wrong* file passes any "referenced assets exist" check, so identity is
+// proven by client-side navigation into a route whose `clientLoader` and lazy
+// `import()` have to run from the manifest-resolved module.
+
+type Scheme = {
+  name: string;
+  /** Extra rsbuild config object body (inside `defineConfig({ ... })`). */
+  config: string;
+  /** Emitted entry.client file under build/client (posix, no query). */
+  entryFile: RegExp;
+  /** Emitted routes/page file under build/client (posix, no query). */
+  routeFile: RegExp;
+  /** Manifest URL for the routes/page module (may include a query). */
+  routeModuleUrl: RegExp;
+  /** Emitted async chunk (lazy import) under build/client. */
+  asyncFile: RegExp;
+};
+
+const HASH = "[a-f0-9]{6,}";
+
+const schemes: Scheme[] = [
+  {
+    name: "Rsbuild production default",
+    config: "",
+    entryFile: new RegExp(`^static/js/entry\\.client\\.${HASH}\\.js$`),
+    routeFile: new RegExp(`^static/js/routes/page\\.${HASH}\\.js$`),
+    routeModuleUrl: new RegExp(`^/static/js/routes/page\\.${HASH}\\.js$`),
+    asyncFile: new RegExp(`^static/js/async/[^/]+\\.${HASH}\\.js$`),
+  },
+  {
+    name: "output.filenameHash: false",
+    config: "output: { filenameHash: false },",
+    entryFile: /^static\/js\/entry\.client\.js$/,
+    routeFile: /^static\/js\/routes\/page\.js$/,
+    routeModuleUrl: /^\/static\/js\/routes\/page\.js$/,
+    asyncFile: /^static\/js\/async\/[^/]+\.js$/,
+  },
+  {
+    name: "output.filename.js hash-first string",
+    config:
+      "environments: { web: { output: { filename: { js: '[contenthash:8]-[name].js' } } } },",
+    entryFile: /^static\/js\/[a-f0-9]{8}-entry\.client\.js$/,
+    routeFile: /^static\/js\/[a-f0-9]{8}-routes\/page\.js$/,
+    routeModuleUrl: /^\/static\/js\/[a-f0-9]{8}-routes\/page\.js$/,
+    asyncFile: /^static\/js\/async\/[a-f0-9]{8}-[^/]+\.js$/,
+  },
+  {
+    name: "output.filename.js function",
+    config: `environments: { web: { output: { filename: {
+      js: (pathData) => "custom/" + String(pathData.chunk?.name ?? "chunk").replace(/\\//g, "__") + ".[contenthash:6].js",
+    } } } },`,
+    entryFile: /^static\/js\/custom\/entry\.client\.[a-f0-9]{6}\.js$/,
+    routeFile: /^static\/js\/custom\/routes__page\.[a-f0-9]{6}\.js$/,
+    routeModuleUrl: /^\/static\/js\/custom\/routes__page\.[a-f0-9]{6}\.js$/,
+    asyncFile: /^static\/js\/custom\/[^/]+\.[a-f0-9]{6}\.js$/,
+  },
+  {
+    name: "output.filename.js query hash",
+    config:
+      "environments: { web: { output: { filename: { js: '[name].js?v=[contenthash:8]' } } } },",
+    entryFile: /^static\/js\/entry\.client\.js$/,
+    routeFile: /^static\/js\/routes\/page\.js$/,
+    routeModuleUrl: /^\/static\/js\/routes\/page\.js\?v=[a-f0-9]{8}$/,
+    asyncFile: /^static\/js\/async\/[^/]+\.js$/,
+  },
+  {
+    name: "tools.rspack function chunkFilename override",
+    config: `environments: { web: { tools: { rspack: (config) => {
+      config.output.chunkFilename = "static/js/chunks/[name].[contenthash:8].js";
+    } } } },`,
+    entryFile: new RegExp(`^static/js/entry\\.client\\.${HASH}\\.js$`),
+    routeFile: new RegExp(`^static/js/routes/page\\.${HASH}\\.js$`),
+    routeModuleUrl: new RegExp(`^/static/js/routes/page\\.${HASH}\\.js$`),
+    asyncFile: /^static\/js\/chunks\/[^/]+\.[a-f0-9]{8}\.js$/,
+  },
+];
+
+const appFiles = {
+  "react-router.config.ts": reactRouterConfig({}),
+  "app/routes/_index.tsx": js`
+    import { Link } from "react-router";
+    export default function Index() {
+      return (
+        <>
+          <h1 data-home>Home</h1>
+          <Link to="/page" data-link>Go to page</Link>
+        </>
+      );
+    }
+  `,
+  "app/lazy.tsx": js`
+    export default function Lazy() {
+      return <p data-lazy>lazy chunk loaded</p>;
+    }
+  `,
+  "app/routes/page.tsx": js`
+    import { lazy, Suspense, useState } from "react";
+    const Lazy = lazy(() => import("../lazy"));
+
+    export async function clientLoader() {
+      return { source: "clientLoader" };
+    }
+
+    export default function Page({ loaderData }) {
+      const [count, setCount] = useState(0);
+      return (
+        <>
+          <p data-source>{loaderData.source}</p>
+          <button data-inc onClick={() => setCount(count + 1)}>{count}</button>
+          {count > 0 ? (
+            <Suspense fallback={<p data-lazy-fallback>loading</p>}>
+              <Lazy />
+            </Suspense>
+          ) : null}
+        </>
+      );
+    }
+  `,
+};
+
+const listClientFiles = (cwd: string) =>
+  readdirSync(path.join(cwd, "build/client"), { recursive: true })
+    .map(String)
+    .map((file) => file.split(path.sep).join("/"));
+
+const readManifest = (cwd: string, files: string[]) => {
+  const manifestFile = files.find((file) =>
+    /^static\/js\/(?:[^/]+\/)*manifest-[a-f0-9]+\.js$/.test(file),
+  );
+  expect(manifestFile, "browser manifest asset").toBeDefined();
+  const source = readFileSync(
+    path.join(cwd, "build/client", manifestFile!),
+    "utf8",
+  );
+  // `window.__reactRouterManifest={...};` serialized with jsesc (single quotes).
+  const json = source
+    .replace(/^window\.__reactRouterManifest=/, "")
+    .replace(/;$/, "");
+  return new Function(`return (${json});`)() as {
+    entry: { module: string; imports: string[] };
+    routes: Record<string, { module: string; imports?: string[] }>;
+  };
+};
+
+async function exerciseRoute(page: Page, port: number) {
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+  const failed: string[] = [];
+  page.on("response", (response) => {
+    if (response.status() >= 400) failed.push(`${response.status()} ${response.url()}`);
+  });
+
+  await page.goto(`http://localhost:${port}/`, { waitUntil: "networkidle" });
+  await expect(page.locator("[data-home]")).toBeVisible();
+
+  // Client-side navigation loads routes/page from the manifest `module` URL;
+  // the clientLoader only exists in that module.
+  await page.locator("[data-link]").click();
+  await expect(page.locator("[data-source]")).toHaveText("clientLoader");
+  // Hydrated interactivity + async chunk through the browser publicPath.
+  await page.locator("[data-inc]").click();
+  await expect(page.locator("[data-inc]")).toHaveText("1");
+  await expect(page.locator("[data-lazy]")).toHaveText("lazy chunk loaded");
+
+  expect(failed).toEqual([]);
+  expect(pageErrors).toEqual([]);
+}
+
+for (const scheme of schemes) {
+  test.describe(`Browser output filenames: ${scheme.name}`, () => {
+    let cwd: string;
+    let port: number;
+    let stop: () => Promise<void> | void;
+
+    test.beforeAll(async () => {
+      port = await getPort();
+      cwd = await createProject({
+        ...appFiles,
+        "rsbuild.config.ts": `
+          import { defineConfig } from "@rsbuild/core";
+          import { pluginReact } from "@rsbuild/plugin-react";
+          import { pluginReactRouter } from "rsbuild-plugin-react-router";
+
+          export default defineConfig({
+            plugins: [pluginReact(), pluginReactRouter()],
+            ${await rsbuildConfig.server({ port })}
+            ${scheme.config}
+          });
+        `,
+      });
+      const result = build({ cwd });
+      expect(result.stderr.toString()).toBe("");
+      expect(result.status).toBe(0);
+      stop = await reactRouterServe({ cwd, port });
+    });
+    test.afterAll(async () => {
+      await stop?.();
+    });
+
+    test("emits files with the configured scheme and the manifest references them", async () => {
+      const files = listClientFiles(cwd);
+      expect(files.filter((f) => scheme.entryFile.test(f))).toHaveLength(1);
+      expect(files.filter((f) => scheme.routeFile.test(f))).toHaveLength(1);
+      expect(files.filter((f) => scheme.asyncFile.test(f)).length).toBeGreaterThan(0);
+
+      const manifest = readManifest(cwd, files);
+      expect(manifest.routes["routes/page"].module).toMatch(scheme.routeModuleUrl);
+      // The entry module URL must be the emitted entry file (plus any query).
+      const entryUrl = manifest.entry.module.split("?")[0].replace(/^\//, "");
+      expect(files).toContain(entryUrl);
+      expect(manifest.entry.imports).not.toContain(manifest.entry.module);
+    });
+
+    test("manifest URLs resolve to the emitted JavaScript", async ({ request }) => {
+      const manifest = readManifest(cwd, listClientFiles(cwd));
+      for (const url of [
+        manifest.entry.module,
+        ...manifest.entry.imports,
+        manifest.routes["routes/page"].module,
+      ]) {
+        const response = await request.get(`http://localhost:${port}${url}`);
+        expect(response.status(), url).toBe(200);
+        expect(response.headers()["content-type"], url).toMatch(/javascript/);
+      }
+    });
+
+    test("routes hydrate and navigate through the manifest modules", async ({ page }) => {
+      await exerciseRoute(page, port);
+    });
+  });
+}

--- a/tests/react-router-framework/integration/route-entry-names-test.ts
+++ b/tests/react-router-framework/integration/route-entry-names-test.ts
@@ -56,8 +56,11 @@ test.describe("Route entry names", () => {
 
     expect(emitted.filter(leaking)).toEqual([]);
 
-    // The route chunk must be a sibling of the route entry itself.
-    expect(emitted).toContain("static/js/routes/customers-client-loader.js");
+    // The route chunk must be a sibling of the route entry itself, and carry
+    // Rsbuild's production content hash: the plugin must not force
+    // `output.filename.js` back to `[name].js` (#129).
+    const routeChunkFile = /^static[/\\]js[/\\]routes[/\\]customers-client-loader\.[a-f0-9]{8,}\.js$/;
+    expect(emitted.filter((file) => routeChunkFile.test(file))).toHaveLength(1);
 
     let manifestFile = emitted.find((file) =>
       /static[/\\]js[/\\]manifest-[^/\\]+\.js$/.test(file),
@@ -77,7 +80,11 @@ test.describe("Route entry names", () => {
     expect(assetUrls.filter(leaking)).toEqual([]);
     // An entry name starting with `/` produced a `/static/js//...` double slash.
     expect(assetUrls.filter((url) => url.includes("//"))).toEqual([]);
-    expect(assetUrls).toContain("/static/js/routes/customers-client-loader.js");
+    expect(
+      assetUrls.filter((url) =>
+        /^\/static\/js\/routes\/customers-client-loader\.[a-f0-9]{8,}\.js$/.test(url),
+      ),
+    ).toHaveLength(1);
 
     // The route id itself stays absolute: it is the runtime contract behind
     // `useRouteLoaderData(id)` and `matches[].id`, and must not be sanitized.

--- a/tests/react-router-framework/integration/rsc-asset-prefix-auto-test.ts
+++ b/tests/react-router-framework/integration/rsc-asset-prefix-auto-test.ts
@@ -1,0 +1,210 @@
+import getPort from "get-port";
+import { test, expect, type Page } from "@playwright/test";
+
+import { css, js } from "./helpers/create-fixture.js";
+import {
+  build,
+  createProject,
+  customDev,
+  reactRouterConfig,
+} from "./helpers/rsbuild.js";
+
+// RSC framework mode with the browser compiler on `'auto'` and the server's
+// initial asset URLs on a root prefix (#130). Everything the server renders
+// from the rspack RSC manifest -- bootstrap scripts, route stylesheet links,
+// and Flight's client-chunk preload prefix -- must use the server prefix, not
+// the `/` rspack records for an automatic browser public path. Assets are only
+// reachable at the configured location; the page origin 404s `/static/*`.
+
+const ROUTE_CSS_COLOR = "rgb(0, 128, 0)";
+const ASYNC_CSS_COLOR = "rgb(255, 0, 0)";
+
+const appFiles = {
+  "react-router.config.ts": reactRouterConfig({}),
+  "app/styles/index.css": css`
+    .route-css {
+      color: ${ROUTE_CSS_COLOR};
+    }
+  `,
+  "app/components/async-component.css": css`
+    .async-component {
+      color: ${ASYNC_CSS_COLOR};
+    }
+  `,
+  "app/components/async-component.tsx": js`
+    "use client";
+    import "./async-component.css";
+    export default function AsyncComponent() {
+      return <p data-async className="async-component">async css</p>;
+    }
+  `,
+  "app/components/counter.tsx": js`
+    "use client";
+    import { lazy, Suspense, useState } from "react";
+    const AsyncComponent = lazy(() => import("./async-component"));
+
+    export function Counter() {
+      const [count, setCount] = useState(0);
+      return (
+        <>
+          <button data-inc onClick={() => setCount(count + 1)}>{count}</button>
+          {count > 0 ? (
+            <Suspense fallback={<p data-fallback>loading</p>}>
+              <AsyncComponent />
+            </Suspense>
+          ) : null}
+        </>
+      );
+    }
+  `,
+  // Server component route with a stylesheet: the route transform streams the
+  // manifest's `entryCssFiles` as <link> tags from the server.
+  "app/routes/_index.tsx": js`
+    import "../styles/index.css";
+    import { Counter } from "../components/counter";
+
+    export default function Index() {
+      return (
+        <>
+          <h1 data-home className="route-css">Home</h1>
+          <Counter />
+        </>
+      );
+    }
+  `,
+  "server.mjs": js`
+    import { createRequestListener } from "@remix-run/node-fetch-server";
+    import express from "express";
+
+    const build = (await import("./build/server/index.js")).default;
+    const app = express();
+    // Page origin: documents and RSC payloads only. No static assets.
+    app.all("*", createRequestListener(build.fetch));
+    app.listen(Number(process.env.PORT), () => console.log("app on " + process.env.PORT));
+
+    const cdn = express();
+    cdn.use((_req, res, next) => {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      next();
+    });
+    cdn.use(process.env.CDN_MOUNT, express.static("build/client", { index: false }));
+    cdn.listen(Number(process.env.CDN_PORT), () => console.log("cdn on " + process.env.CDN_PORT));
+  `,
+};
+
+async function collectAssetRequests(page: Page) {
+  const requests: string[] = [];
+  const failures: string[] = [];
+  const errors: Error[] = [];
+  page.on("request", (request) => {
+    if (/\.(?:m?js|css)(?:\?|$)/.test(request.url())) requests.push(request.url());
+  });
+  page.on("response", (response) => {
+    if (response.status() >= 400) failures.push(`${response.status()} ${response.url()}`);
+  });
+  page.on("pageerror", (error) => errors.push(error));
+  return { requests, failures, errors };
+}
+
+test.describe("RSC: web assetPrefix 'auto' with assets on a CDN sub-path", () => {
+  let port: number;
+  let cdnPort: number;
+  let assetBase: string;
+  let stop: () => Promise<void> | void;
+
+  test.beforeAll(async () => {
+    port = await getPort();
+    cdnPort = await getPort();
+    assetBase = `http://localhost:${cdnPort}/cdn/app/`;
+    const cwd = await createProject(
+      {
+        ...appFiles,
+        "rsbuild.config.ts": `
+          import { defineConfig } from "@rsbuild/core";
+          import { pluginReact } from "@rsbuild/plugin-react";
+          import { pluginReactRouterRSC } from "rsbuild-plugin-react-router";
+
+          export default defineConfig({
+            plugins: [pluginReact(), pluginReactRouterRSC({ customServer: true })],
+            output: { assetPrefix: ${JSON.stringify(assetBase)} },
+            environments: { web: { output: { assetPrefix: "auto" } } },
+          });
+        `,
+      },
+      "rsc-framework",
+    );
+    const result = build({ cwd });
+    expect(result.stderr.toString()).toBe("");
+    expect(result.status).toBe(0);
+    stop = await customDev({
+      cwd,
+      port,
+      env: {
+        NODE_ENV: "production",
+        PORT: String(port),
+        CDN_PORT: String(cdnPort),
+        CDN_MOUNT: "/cdn/app",
+      },
+    });
+  });
+  test.afterAll(async () => {
+    await stop?.();
+  });
+
+  test("the page origin does not serve assets", async ({ request }) => {
+    const response = await request.get(`http://localhost:${port}/static/js/missing.js`);
+    expect(response.status()).toBe(404);
+  });
+
+  test("server-rendered bootstrap scripts and route stylesheets use the CDN prefix", async ({
+    request,
+  }) => {
+    const response = await request.get(`http://localhost:${port}/`);
+    expect(response.status()).toBe(200);
+    const html = await response.text();
+
+    const scripts = [...html.matchAll(/<script[^>]+src="([^"]+)"/g)].map((m) => m[1]);
+    const stylesheets = [...html.matchAll(/<link[^>]+rel="stylesheet"[^>]+href="([^"]+)"/g)].map(
+      (m) => m[1],
+    );
+    expect(scripts.length).toBeGreaterThan(0);
+    expect(stylesheets.length).toBeGreaterThan(0);
+    for (const url of [...scripts, ...stylesheets]) {
+      expect(url.startsWith(assetBase), `server-rendered URL ${url}`).toBe(true);
+    }
+    // Rspack records '/' for an automatic public path; none of it may leak.
+    expect(html).not.toMatch(/(?:src|href)="\/static\//);
+  });
+
+  test("route CSS applies before hydration and async CSS loads from the CDN after", async ({
+    page,
+  }) => {
+    const { requests, failures, errors } = await collectAssetRequests(page);
+
+    // Before hydration: block scripts so only server-rendered markup and
+    // stylesheets are in play.
+    await page.route("**/*.js", (route) => route.abort());
+    await page.goto(`http://localhost:${port}/`);
+    await expect(page.locator("[data-home]")).toHaveCSS("color", ROUTE_CSS_COLOR);
+    await page.unroute("**/*.js");
+
+    // After hydration: interaction works and the async stylesheet is fetched
+    // from the CDN by the browser runtime's automatic public path.
+    await page.goto(`http://localhost:${port}/`, { waitUntil: "networkidle" });
+    await expect(page.locator("[data-home]")).toHaveCSS("color", ROUTE_CSS_COLOR);
+    const cssResponse = page.waitForResponse((response) =>
+      /\/static\/css\/async\//.test(response.url()),
+    );
+    await page.locator("[data-inc]").click();
+    await expect(page.locator("[data-inc]")).toHaveText("1");
+    const asyncCss = await cssResponse;
+    expect(asyncCss.url().startsWith(`${assetBase}static/css/async/`), asyncCss.url()).toBe(true);
+    await expect(page.locator("[data-async]")).toHaveCSS("color", ASYNC_CSS_COLOR);
+
+    for (const url of requests) {
+      expect(url.startsWith(assetBase), `asset request ${url}`).toBe(true);
+    }
+    expect(failures.filter((f) => !/\.js$/.test(f))).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+});

--- a/tests/rsc-support.test.ts
+++ b/tests/rsc-support.test.ts
@@ -65,9 +65,24 @@ describe('RSC support helpers', () => {
     });
 
     expect(modules['virtual/react-router/server-build']).toBeUndefined();
-    expect(
-      modules['virtual/react-router/unstable_rsc/bootstrap-scripts']
-    ).toContain('/assets/custom/js/index.js');
+    // Bootstrap scripts come from the rspack RSC manifest at runtime (so hashed
+    // entry filenames work); the computed path is only the fallback.
+    const bootstrapScripts =
+      modules['virtual/react-router/unstable_rsc/bootstrap-scripts'];
+    expect(bootstrapScripts).toContain('__webpack_require__.rscM?.entryJsFiles');
+    expect(bootstrapScripts).toContain('["/assets/custom/js/index.js"]');
+    const evaluate = (rscM: unknown) =>
+      new Function(
+        '__webpack_require__',
+        bootstrapScripts.replace('export default', 'return')
+      )({ rscM });
+    expect(evaluate({ entryJsFiles: ['/cdn/static/js/index.abc123.js'] })).toEqual(
+      ['/cdn/static/js/index.abc123.js']
+    );
+    expect(evaluate({ entryJsFiles: [] })).toEqual([
+      '/assets/custom/js/index.js',
+    ]);
+    expect(evaluate(undefined)).toEqual(['/assets/custom/js/index.js']);
     // The RSC HMR runtime only self-accepts; the single `rsc:update` navigate
     // handler now lives in the RSC client entry, not this virtual module.
     expect(

--- a/tests/rsc-support.test.ts
+++ b/tests/rsc-support.test.ts
@@ -67,35 +67,67 @@ describe('RSC support helpers', () => {
     expect(modules['virtual/react-router/server-build']).toBeUndefined();
     // Bootstrap scripts come from the rspack RSC manifest at runtime (so hashed
     // entry filenames work); the computed path is only the fallback.
-    const bootstrapScripts =
-      modules['virtual/react-router/unstable_rsc/bootstrap-scripts'];
-    expect(bootstrapScripts).toContain('["/assets/custom/js/index.js"]');
-    const evaluate = (rscM: unknown) =>
-      new Function(
+    // The manifest-prefix module aligns `__webpack_require__.rscM` in place and
+    // the bootstrap module then reads it. Evaluate both as plain scripts.
+    const evaluate = (rscM: any) => {
+      const rscManifest = new Function(
         '__webpack_require__',
-        bootstrapScripts.replace('export default', 'return')
+        modules['virtual/react-router/unstable_rsc/manifest-prefix'].replace(
+          'export const rscManifest =',
+          'return'
+        )
       )({ rscM });
-    // Manifest entries already carry the prefix the server uses: pass through
-    // untouched, preserving the full list and its order.
-    expect(
-      evaluate({
-        entryJsFiles: ['/assets/static/js/index.abc123.js', '/assets/static/js/polyfill.js'],
-        moduleLoading: { prefix: '/assets/' },
-      })
-    ).toEqual(['/assets/static/js/index.abc123.js', '/assets/static/js/polyfill.js']);
-    // Browser compiler on 'auto' (rspack records `/`), server prefix differs:
-    // swap the applied prefix for the server prefix, never stack a second one.
-    expect(
-      evaluate({
-        entryJsFiles: ['/static/js/index.abc123.js'],
-        moduleLoading: { prefix: '/' },
-      })
-    ).toEqual(['/assets/static/js/index.abc123.js']);
-    // Missing manifest data falls back to the computed entry path.
-    expect(evaluate({ entryJsFiles: [] })).toEqual([
-      '/assets/custom/js/index.js',
+      const bootstrap = new Function(
+        'rscManifest',
+        modules['virtual/react-router/unstable_rsc/bootstrap-scripts']
+          .replace(/^import .*\n/, '')
+          .replace('export default', 'return')
+      )(rscManifest) as string[];
+      return { bootstrap, rscM };
+    };
+    // Manifest already carries the prefix the server uses: untouched, with
+    // the full list and its order preserved.
+    const same = evaluate({
+      entryJsFiles: ['/assets/static/js/index.abc123.js', '/assets/static/js/polyfill.js'],
+      entryCssFiles: { 'root.tsx': ['/assets/static/css/root.css'] },
+      clientManifest: { a: { cssFiles: ['/assets/static/css/a.css'] } },
+      moduleLoading: { prefix: '/assets/' },
+    });
+    expect(same.bootstrap).toEqual([
+      '/assets/static/js/index.abc123.js',
+      '/assets/static/js/polyfill.js',
     ]);
-    expect(evaluate(undefined)).toEqual(['/assets/custom/js/index.js']);
+    expect(same.rscM.entryCssFiles['root.tsx']).toEqual(['/assets/static/css/root.css']);
+    expect(same.rscM.moduleLoading.prefix).toBe('/assets/');
+    // Browser compiler on 'auto' (rspack records `/`), server prefix differs:
+    // bootstrap scripts, route CSS, client-reference CSS, and Flight's preload
+    // prefix all move to the server prefix, never stacking a second one.
+    const entryCss = ['/static/css/async/768.css'];
+    const swapped = evaluate({
+      entryJsFiles: ['/static/js/index.abc123.js'],
+      entryCssFiles: { 'root.tsx': entryCss },
+      clientManifest: {
+        a: { cssFiles: ['/static/css/async/757.css', 'https://other.example/x.css'] },
+        b: {},
+      },
+      moduleLoading: { prefix: '/' },
+    });
+    expect(swapped.bootstrap).toEqual(['/assets/static/js/index.abc123.js']);
+    // Mutated in place: consumers that captured the array earlier see it too.
+    expect(entryCss).toEqual(['/assets/static/css/async/768.css']);
+    expect(swapped.rscM.clientManifest.a.cssFiles).toEqual([
+      '/assets/static/css/async/757.css',
+      'https://other.example/x.css',
+    ]);
+    expect(swapped.rscM.moduleLoading.prefix).toBe('/assets/');
+    // Idempotent: a second evaluation must not re-prefix.
+    evaluate(swapped.rscM);
+    expect(swapped.rscM.entryJsFiles).toEqual(['/assets/static/js/index.abc123.js']);
+    // No entry script recorded (rspack drops non-`.js` names): fail loudly
+    // rather than render a document that cannot hydrate.
+    expect(() =>
+      evaluate({ entryJsFiles: [], moduleLoading: { prefix: '/' } })
+    ).toThrow(/lists no browser entry script/);
     // The RSC HMR runtime only self-accepts; the single `rsc:update` navigate
     // handler now lives in the RSC client entry, not this virtual module.
     expect(

--- a/tests/rsc-support.test.ts
+++ b/tests/rsc-support.test.ts
@@ -69,16 +69,29 @@ describe('RSC support helpers', () => {
     // entry filenames work); the computed path is only the fallback.
     const bootstrapScripts =
       modules['virtual/react-router/unstable_rsc/bootstrap-scripts'];
-    expect(bootstrapScripts).toContain('__webpack_require__.rscM?.entryJsFiles');
     expect(bootstrapScripts).toContain('["/assets/custom/js/index.js"]');
     const evaluate = (rscM: unknown) =>
       new Function(
         '__webpack_require__',
         bootstrapScripts.replace('export default', 'return')
       )({ rscM });
-    expect(evaluate({ entryJsFiles: ['/cdn/static/js/index.abc123.js'] })).toEqual(
-      ['/cdn/static/js/index.abc123.js']
-    );
+    // Manifest entries already carry the prefix the server uses: pass through
+    // untouched, preserving the full list and its order.
+    expect(
+      evaluate({
+        entryJsFiles: ['/assets/static/js/index.abc123.js', '/assets/static/js/polyfill.js'],
+        moduleLoading: { prefix: '/assets/' },
+      })
+    ).toEqual(['/assets/static/js/index.abc123.js', '/assets/static/js/polyfill.js']);
+    // Browser compiler on 'auto' (rspack records `/`), server prefix differs:
+    // swap the applied prefix for the server prefix, never stack a second one.
+    expect(
+      evaluate({
+        entryJsFiles: ['/static/js/index.abc123.js'],
+        moduleLoading: { prefix: '/' },
+      })
+    ).toEqual(['/assets/static/js/index.abc123.js']);
+    // Missing manifest data falls back to the computed entry path.
     expect(evaluate({ entryJsFiles: [] })).toEqual([
       '/assets/custom/js/index.js',
     ]);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -79,14 +79,6 @@ const deepMerge = (base: any, overrides: any): any => {
   if (!overrides || typeof overrides !== 'object') {
     return base;
   }
-  // Like `mergeRsbuildConfig` for `tools.*`: a function merged with an object
-  // becomes an ordered list that Rsbuild later applies in sequence.
-  if (typeof base === 'function') {
-    return [base, overrides];
-  }
-  if (Array.isArray(base) && !Array.isArray(overrides)) {
-    return [...base, overrides];
-  }
   if (!base || typeof base !== 'object') {
     return overrides;
   }
@@ -231,40 +223,22 @@ rstest.mock('@scripts/test-helper', () => ({
       }
     });
 
+    // Hooks register (and push their promises) while `setup` is still running,
+    // so drain `pending` until no new work appears; otherwise a rejected
+    // config hook would go unobserved.
+    const settlePending = async () => {
+      let settled = 0;
+      while (settled < pending.length) {
+        const batch = pending.slice(settled);
+        settled = pending.length;
+        await Promise.all(batch);
+      }
+    };
     stub.unwrapConfig.mockImplementation(async () => {
-      await Promise.all(pending);
+      await settlePending();
       return mergedConfig;
     });
 
-    // Apply the recorded `modifyRspackConfig` handlers for one environment and
-    // return the resulting Rspack config, mirroring Rsbuild's hook order (the
-    // handlers run before the user's `tools.rspack`, which is applied last).
-    const rspackHandlers: any[] = [];
-    stub.modifyRspackConfig.mockImplementation((handler: any) => {
-      rspackHandlers.push(handler);
-    });
-    stub.unwrapRspackConfig = rstest.fn().mockImplementation(
-      async (environmentName: string, initial: any = {}) => {
-        await Promise.all(pending);
-        let current = initial;
-        const utils = {
-          environment: { name: environmentName },
-          mergeConfig: (a: any, b: any) => deepMerge(a, b),
-        };
-        for (const handler of rspackHandlers) {
-          current = (await handler(current, utils)) ?? current;
-        }
-        const toolsRspack = mergedConfig.environments?.[environmentName]?.tools?.rspack;
-        for (const entry of [toolsRspack].flat()) {
-          if (typeof entry === 'function') {
-            current = (await entry(current, utils)) ?? current;
-          } else if (entry) {
-            current = deepMerge(current, entry);
-          }
-        }
-        return current;
-      }
-    );
 
     return stub;
   }),

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -79,6 +79,14 @@ const deepMerge = (base: any, overrides: any): any => {
   if (!overrides || typeof overrides !== 'object') {
     return base;
   }
+  // Like `mergeRsbuildConfig` for `tools.*`: a function merged with an object
+  // becomes an ordered list that Rsbuild later applies in sequence.
+  if (typeof base === 'function') {
+    return [base, overrides];
+  }
+  if (Array.isArray(base) && !Array.isArray(overrides)) {
+    return [...base, overrides];
+  }
   if (!base || typeof base !== 'object') {
     return overrides;
   }
@@ -167,6 +175,7 @@ rstest.mock('@scripts/test-helper', () => ({
       getNormalizedConfig: rstest.fn().mockImplementation(() => mergedConfig),
       isPluginExists: rstest.fn().mockReturnValue(false),
       modifyRsbuildConfig: rstest.fn(),
+      modifyRspackConfig: rstest.fn(),
       modifyBundlerChain: rstest.fn(),
       onAfterEnvironmentCompile: rstest.fn(),
       // Keep as a spy-only hook; tests in this repo assert against the merged
@@ -226,6 +235,36 @@ rstest.mock('@scripts/test-helper', () => ({
       await Promise.all(pending);
       return mergedConfig;
     });
+
+    // Apply the recorded `modifyRspackConfig` handlers for one environment and
+    // return the resulting Rspack config, mirroring Rsbuild's hook order (the
+    // handlers run before the user's `tools.rspack`, which is applied last).
+    const rspackHandlers: any[] = [];
+    stub.modifyRspackConfig.mockImplementation((handler: any) => {
+      rspackHandlers.push(handler);
+    });
+    stub.unwrapRspackConfig = rstest.fn().mockImplementation(
+      async (environmentName: string, initial: any = {}) => {
+        await Promise.all(pending);
+        let current = initial;
+        const utils = {
+          environment: { name: environmentName },
+          mergeConfig: (a: any, b: any) => deepMerge(a, b),
+        };
+        for (const handler of rspackHandlers) {
+          current = (await handler(current, utils)) ?? current;
+        }
+        const toolsRspack = mergedConfig.environments?.[environmentName]?.tools?.rspack;
+        for (const entry of [toolsRspack].flat()) {
+          if (typeof entry === 'function') {
+            current = (await entry(current, utils)) ?? current;
+          } else if (entry) {
+            current = deepMerge(current, entry);
+          }
+        }
+        return current;
+      }
+    );
 
     return stub;
   }),


### PR DESCRIPTION
Fixes #129 and #130.

Both issues share one root cause: the plugin merged its own web config *over* the user's, and its `tools.rspack` object was applied after the user's `tools.rspack`. One PR because the fix is one mechanism.

## What changed

**Browser JavaScript filenames are Rsbuild's (#129)**
The plugin no longer forces web `output.filename.js` to `[name].js` and no longer sets the classic-mode async `chunkFilename`. `output.filename.js` (string *or function*), `output.filenameHash`, `output.distPath.jsAsync`, and query-hash filenames are honored. The browser manifest classifies emitted assets by pathname (`.js`/`.mjs`/`.cjs`, with or without a query), keeps the full emitted reference, excludes `.hot-update.js`, and no longer reverse-engineers chunk ownership from filenames. A chunk whose metadata names no script fails the build instead of inventing a path.

**Web `output.publicPath` is no longer set by the plugin (#130)**
Rsbuild derives it from the web environment's `output.assetPrefix`, so `'auto'` reaches the browser runtime. The server build and browser manifest need an absolute prefix: they use the web prefix when usable and otherwise fall back to the root prefix, chosen *before* `'auto'` is normalized, so `output.assetPrefix: 'https://cdn/app/'` + web `'auto'` keeps CDN URLs in server output. The lookup reads the web environment from the root normalized config (the environment getter throws for `--environment node`).

**One owner for Rspack output policy** — `src/environment-output.ts` registers both tiers: overridable defaults via `modifyRspackConfig` (which Rsbuild runs before the user's `tools.rspack`, so object and function forms win), and enforced invariants (node `library.type`, federation async startup) via the late `tools.rspack` function. Scope of the "user wins" claim: `tools.rspack`; `tools.bundlerChain` runs earlier.

**RSC: one server-asset-prefix policy** — With the browser compiler on `'auto'`, rspack records `/` as the RSC manifest prefix. `virtual/react-router/unstable_rsc/manifest-prefix` aligns `__webpack_require__.rscM` (which *is* `__rspack_rsc_manifest__`) once, in place: `moduleLoading.prefix`, `entryJsFiles`, `entryCssFiles`, and client references' `cssFiles`. Bootstrap scripts, route stylesheets, react-server-dom-rspack's client-reference stylesheets, and Flight preload hints therefore agree; nothing is rewritten per consumer. Bootstrap reads the aligned `entryJsFiles` (full list, in order); an empty list is an explicit error (rspack's collector only records `*.js`), and RSC mode rejects non-`.js` web `filename.js` at config time. The fallback-only `jsDistPath` plumbing is gone.

**Module Federation (example-level; see #132 for the pre-existing runtime problem)**
The remote container URL was only stable because the plugin forced `[name].js`; the example now names both containers via `ModuleFederationPlugin` `filename`, serves assets with CORS (required for `remoteType: 'import'`), publishes server async chunks where `@module-federation/node` resolves them against the node `publicPath`, and puts the browser compiler on `'auto'`.

## Verification

Unit (675): real-Rsbuild `inspectConfig` output-precedence fixture replaces the stub simulator (removed); real `createRsbuild` with `environment: ['node']`; RSC manifest alignment (in place, idempotent, no double prefix), explicit bootstrap error, RSC filename rejection; classifier table incl. `.mjs`/query/hot-update; no-script chunk error.

Integration (all fail on the pre-fix build, pass now):
- `asset-prefix-auto-test.ts`: fallback scenario (root CDN + web `'auto'`) and a **relocation negative control** (root `/`, assets only on another origin, document + manifest rewritten at the serving boundary, compiled runtime untouched). Probes an emitted asset at the wrong origin (404). Restoring the forced `publicPath` makes the relocation case request async CSS from the page origin and fail (verified); soft assertion on the final compiler `publicPath: 'auto'`.
- `rsc-asset-prefix-auto-test.ts`: RSC route CSS + client-reference CSS + bootstrap on a CDN sub-path, page origin 404s assets, styles before and after hydration, async CSS via `'auto'`.
- `output-filename-test.ts`: six schemes, one scenario each with named steps; one manifest read via `window.__reactRouterManifest`; identity proven by client navigation + `clientLoader` + lazy import; responses observed from the browser.
- `federation-test.ts`: minimal host/remote fixture (container from origin B, build-time prefix on origin A which refuses async CSS, CORS). **`test.fixme`**: with `federation: true` the production host never hydrates under MF `asyncStartup`, and a Node consumer's async server build resolves to `undefined` — reproduces identically with `main`'s plugin build and matches the Epic Stack host failing to boot on `main`. Tracked in #132.

Suites: React Router integration 1043 passed (incl. HMR/HDR); all 8 example e2e suites; typecheck + prettier clean; CI green at `4921226` (this push pending).
